### PR TITLE
Add support for flat field and gain reference files.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Contents
    romanisim/image
    romanisim/l1
    romanisim/l2
+   romanisim/refs
 
    romanisim/catalog
    romanisim/apt

--- a/docs/romanisim/refs.rst
+++ b/docs/romanisim/refs.rst
@@ -1,0 +1,32 @@
+Reference files
+===============
+
+romanisim uses reference files from `CRDS <https://hst-crds.stsci.edu/static/users_guide/index.html>`_ in order to simulate realistic images.  The following kinds of reference files are used:
+
+* read noise
+* dark current
+* flat field
+* gain
+* distortion map
+
+The usage of these is mostly straightforward, but we provide here a few notes.
+
+Read Noise
+----------
+The random noise on reading a sample contributing to a ramp in an L1 image is scaled by the read noise reference file.
+
+Dark Current
+------------
+CRDS provides dark current images for each possible MA table, including the averaging of the dark current into resultants.  This simplifies subtraction from L1 images and allows effects beyond a simple Poisson sampling of dark current electrons in each read.  But it's unwieldy for a simulator because any effects beyond simple Poisson sampling of dark current electrons are not presently defined well enough to allow simulation.  So the simulator simply takes the last resultant in the dark current resultant image and scales it by the effective exposure time of that resultant to get a dark current rate.  This rate then goes into the idealized "counts" image which is then apportioned into the reads making up the resultants of an L1 image.
+
+Flat field
+----------
+Implementation of the flat field requires a little care due to the desire to support galsim's "photon shooting" rendering mode.  This mode does not create noise-free images but instead only simulates the number of photons that would be actually detected in a device.  We want to start by simulating the number of photons each pixel would record for a flat field of 1, and then sample that down by a fraction corresponding to the actual QE of each pixel.  That works fine supposing that the flat field is less than 1, but does not work for values of the flat field greater than 1.  So we instead do the initial galsim simulations for a larger exposure time than necessary, scaled by the maximum value of the flat field, and then sample down by :math:`\mathrm{flat}/\mathrm{maxflat}`.  That's all well and good as long as there aren't any spurious very large values in the flat field.  I haven't actually seen any such values yet and so haven't tried to address that case (e.g., by clipping them).
+
+Gain
+----
+Photons from the idealized "counts" image are scaled down to ADU before quantization during L1 creation, and then converted back to electrons before ramp fitting when making L2 images.
+
+Distortion map
+--------------
+World coordinate systems for WFI images are created by placing the telescope boresight at :math:`\mathrm{V2} = \mathrm{V3} = 0`, and then applying the distortion maps from CRDS to convert from V2V3 to pixels.

--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -64,7 +64,7 @@ def make_dummy_catalog(coord, radius=0.1, rng=None, seed=42, nobj=1000,
     objlist = []
     locs = util.random_points_in_cap(coord, radius, nobj, rng=rng)
     for i in range(nobj):
-        sky_pos = locs[i]
+        sky_pos = util.celestialcoord(locs[i])
         p = rng()
         # prescription follows galsim demo13.
         if p < 0.8:  # 80% of targets; faint galaxies
@@ -157,8 +157,8 @@ def make_dummy_table_catalog(coord, radius=0.1, rng=None, nobj=1000,
     hlr[star] = 0
 
     out = table.Table()
-    out['ra'] = [x.ra.deg for x in locs]
-    out['dec'] = [x.dec.deg for x in locs]
+    out['ra'] = locs.ra.to(u.deg).value
+    out['dec'] = locs.dec.to(u.deg).value
     out['type'] = types
     out['n'] = sersic_index
     out['half_light_radius'] = hlr

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -164,7 +164,7 @@ def tij_to_pij(tij):
             tremaining -= (t - tlast)
             tlast = t
         pij.append(pi)
-    return pij
+    return np.clip(pij, 0, 1)
 
 
 def apportion_counts_to_resultants(counts, tij):
@@ -339,7 +339,8 @@ def ma_table_to_tij(ma_table_number):
 
 
 def make_l1(counts, ma_table_number,
-            read_noise=None, filepath=None, rng=None, seed=None):
+            read_noise=None, filepath=None, rng=None, seed=None,
+            gain=None):
     """Make an L1 image from a counts image.
 
     This apportions the total counts among the different resultants and adds
@@ -362,6 +363,8 @@ def make_l1(counts, ma_table_number,
         Random number generator to use
     seed : int
         Seed for populating RNG.  Only used if rng is None.
+    gain : float or np.ndarray[float]
+        Gain (electrons / count) for converting counts to electrons
 
     Returns
     -------
@@ -407,6 +410,6 @@ def make_l1(counts, ma_table_number,
     log.warning('We need to make sure we have the right units on the read '
                 'noise.')
 
-    resultants /= roman.gain
+    resultants /= gain
     resultants = np.round(resultants)
     return resultants

--- a/romanisim/ramp.py
+++ b/romanisim/ramp.py
@@ -347,7 +347,12 @@ class RampFitInterpolator:
         fluxonreadvar = np.clip(
             fluxonreadvar, self.flux_on_readvar_pts[0],
             self.flux_on_readvar_pts[-1])
-        return self.var_interpolator(fluxonreadvar).astype('f4')*read_noise**2
+        var = self.var_interpolator(fluxonreadvar).astype('f4')
+        read_noise = np.array(read_noise)
+        read_noise = read_noise.reshape(
+            read_noise.shape + (1,)*(len(var.shape)-len(read_noise.shape)))
+        var *= read_noise**2
+        return var
 
     def fit_ramps(self, resultants, read_noise, fluxest=None):
         """Fit ramps for a set of resultants and their read noise.

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -119,8 +119,7 @@ def random_points_in_cap(coord, radius, nobj, rng=None):
     dist = np.arccos(1-(1-np.cos(np.radians(radius)))*dist)
     c1 = SkyCoord(coord.ra.rad*u.rad, coord.dec.rad*u.rad, frame='icrs')
     c1 = c1.directional_offset_by(ang*u.rad, dist*u.rad)
-    sky_pos = [celestialcoord(x) for x in c1]
-    return sky_pos
+    return c1
 
 
 def flatten_dictionary(d):


### PR DESCRIPTION
This PR adds support for flat fields and gains.

CRDS currently supplies flat fields only for F158, so a flat field of 1 (i.e., no-op) is used when a flat field cannot be found.

The implementation is slightly interesting because of the goal of continuing to support galsim's "photon shooting" mode.  The simulation has an initial phase where it figures out how many photons should enter each pixel over the whole exposure time, and then plays games figuring out how many of those photons enter each read & resultant, and how those eventually get translated into slopes.

For if all flat values were less than one, it would be straightforward to take the simulated image and sample it via the binomial distribution down to the "effective" time of each pixel---ignoring any chromaticity of the flat field.

For flat field values greater than one, that doesn't work.  We address this by making the initial simulated image correspond to an exposure time of exptime * max(flat), and then sampling down all of the pixels by flat.  I think that makes sense and is well defined, but it will be badly behaved if flat fields contain a small number of spuriously large values.  We could think about clipping the flat field, etc., but at present I ignore this.

The gain reference files are easier; gains are applied in inverse before quantization when making L1 images, and then applied again before fitting ramps to take the resultants into electrons.

Also included are some minor changes:
- random_points_in_cap now returns SkyCoords rather than CelestialCoords, to speed vectorization when given large catalogs.
- the dark image was not being included
- when allocating photons to reads, numerical noise could lead to np.random.binomial(...) being asked for more than 100% of the photons in the last bin.  The requested fractions are now clipped to 0-1.