### PR TITLE
Implement classical non-linearity

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,7 @@
 
 [flake8]
 select = F, W, E, C
+ignore = W503
 # We should set max line length lower eventually
 max-line-length = 130
 exclude =

--- a/docs/romanisim/l1.rst
+++ b/docs/romanisim/l1.rst
@@ -12,7 +12,7 @@ This process proceeds by simulating each read, drawing the appropriate number of
 After apportioning counts to resultants, systematic effects are added to the resultants.  Presently only read noise is added.  The read noise is averaged down like :math:`1/\sqrt{N}`, where :math:`N` is the number of reads contributing to the resultant.
 
 Nonlinearity
-============
+------------
 
 Non-linearity is considered when L1 images are constructed and a non-linearity model is provided (e.g., from CRDS).  Non-linearity is implemented by including an additional "efficiency" parameter that is the linearity-affected count rate divided by the idealized count rate absent nonlinearity; this is the reciprocal of the derivative of the non-linearity correction function.  Two complications arise:
 
@@ -20,6 +20,8 @@ Non-linearity is considered when L1 images are constructed and a non-linearity m
 2. The efficiency varies over each read; ignoring this effect and using only the efficiency at the start of each reach can lead to 1-2% biases depending on how quickly the efficiency changes with flux.
 
 To address (1), we adjust the probability of the number of counts we draw from the binomial distribution to effectively remove the lost photons from the count.  To mitigate (2), we compute the efficiency for each read based on a guess for what the efficiency will be at the midpoint of the read, after half the charges have been accumulated, based on the idealized count rate for the pixel and the efficiency of the last read.  One could imagine a higher order scheme to do better here, but this reduced the errors to <0.5 mmag.
+
+Note that this picture of nonlinearity is that the pixels are not recording all of the photons in the presence of nonlinearity.  Another picture is that the effective gain changes---i.e., the relationship between recorded counts and photons---but that the Poisson statistics on the number of photons should be consistent with having counted all of the photons.  That's not what the code is doing at the moment, though it's straightforward.
 
 .. automodapi:: romanisim.l1
 .. automodapi:: romanisim.nonlinearity

--- a/docs/romanisim/l1.rst
+++ b/docs/romanisim/l1.rst
@@ -11,4 +11,15 @@ This process proceeds by simulating each read, drawing the appropriate number of
 
 After apportioning counts to resultants, systematic effects are added to the resultants.  Presently only read noise is added.  The read noise is averaged down like :math:`1/\sqrt{N}`, where :math:`N` is the number of reads contributing to the resultant.
 
+Nonlinearity
+============
+
+Non-linearity is considered when L1 images are constructed and a non-linearity model is provided (e.g., from CRDS).  Non-linearity is implemented by including an additional "efficiency" parameter that is the linearity-affected count rate divided by the idealized count rate absent nonlinearity; this is the reciprocal of the derivative of the non-linearity correction function.  Two complications arise:
+
+1. We need to keep track of the number of counts lost due to non-linearity, so we don't apportion them to future reads.
+2. The efficiency varies over each read; ignoring this effect and using only the efficiency at the start of each reach can lead to 1-2% biases depending on how quickly the efficiency changes with flux.
+
+To address (1), we adjust the probability of the number of counts we draw from the binomial distribution to effectively remove the lost photons from the count.  To mitigate (2), we compute the efficiency for each read based on a guess for what the efficiency will be at the midpoint of the read, after half the charges have been accumulated, based on the idealized count rate for the pixel and the efficiency of the last read.  One could imagine a higher order scheme to do better here, but this reduced the errors to <0.5 mmag.
+
 .. automodapi:: romanisim.l1
+.. automodapi:: romanisim.nonlinearity

--- a/docs/romanisim/l2.rst
+++ b/docs/romanisim/l2.rst
@@ -9,11 +9,8 @@ Ramps are currently fit using "optimal" weighting, considering the full covarian
 
 This approach does not handle cosmic rays or saturated pixels well, though for modest sized sets of resultants introducing an additional series of fits for the roughly :math:`2 n_\mathrm{resultant}` sub-ramps would be straightforward.  That approach would also naturally handle saturated ramps.  Even explicitly computing every possible :math:`n_\mathrm{resultant} (n_\mathrm{resultant} - 1) / 2` subramp would likely still be quite inexpensive for modestly sized ramps.
 
-This is a fairly faithful representation of how level two image construction works, so there are not many additional effects to add here.  Some things that haven't yet been fully baked:
+This is a fairly faithful representation of how level two image construction works, so there are not many additional effects to add here.
 
-* We should put in a flat field for each pixel.  That comes in as an additional draw from the counts image according to how non-ideal each pixel is, in the total counts image.
-* We need to think about gain images.
-* We are ignoring non-linearities both here and at the L1 stage.
 * We are ignoring saturation both here and at the L1 stage.
 
 .. automodapi:: romanisim.ramp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ norecursedirs = [
     'docs/_build',
     'docs/exts',
     'scripts',
+    'build',
     '.tox',
 ]
 doctest_plus = 'enabled'

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -18,6 +18,7 @@ from . import wcs
 from . import catalog
 from . import parameters
 from . import util
+from . import nonlinearity
 import romanisim.l1
 import romanisim.bandpass
 import romanisim.psf
@@ -53,7 +54,8 @@ import crds
 # these would each be optional arguments that would override
 
 
-def make_l2(resultants, ma_table, read_noise=None, gain=None, flat=None):
+def make_l2(resultants, ma_table, read_noise=None, gain=None, flat=None,
+            linearity=None):
     """
     Simulate an image in a filter given resultants.
 
@@ -69,6 +71,8 @@ def make_l2(resultants, ma_table, read_noise=None, gain=None, flat=None):
         read_noise image to use.  If None, use galsim.roman.read_noise.
     flat : np.ndarray[float]
         flat field to use
+    linearity : romanisim.nonlinearity.NL object or None
+        non-linearity correction to use.
 
     Returns
     -------
@@ -86,10 +90,12 @@ def make_l2(resultants, ma_table, read_noise=None, gain=None, flat=None):
     if gain is None:
         gain = galsim.roman.gain
 
+    if linearity is not None:
+        resultants = linearity.correct(resultants)
+        # no error propagation
+
     from . import ramp
     rampfitter = ramp.RampFitInterpolator(ma_table)
-    log.warning('Gain should be handled as something more interesting '
-                'than a single constant.')
     ramppar, rampvar = rampfitter.fit_ramps(resultants * gain, read_noise)
     # could iterate if we wanted to improve the flux estimates
 
@@ -363,10 +369,11 @@ def simulate(metadata, objlist,
     if usecrds:
         reffiles = crds.getreferences(
             all_metadata, observatory='roman',
-            reftypes=['readnoise', 'dark', 'gain'])
+            reftypes=['readnoise', 'dark', 'gain', 'linearity'])
         read_noise = asdf.open(reffiles['readnoise'])['roman']['data']
         darkrate = asdf.open(reffiles['dark'])['roman']['data']
         gain = asdf.open(reffiles['gain'])['roman']['data']
+        linearity = asdf.open(reffiles['linearity'])['roman']['coeffs']
         try:
             reffiles = crds.getreferences(
                 all_metadata, observatory='roman',
@@ -375,6 +382,7 @@ def simulate(metadata, objlist,
         except crds.core.exceptions.CrdsLookupError:
             log.warning('Could not find flat; using 1')
             flat = 1
+
         # convert the last dark resultant into a dark rate by dividing by the
         # mean time in that resultant.
         darkrate = darkrate[-1] / (
@@ -383,11 +391,14 @@ def simulate(metadata, objlist,
         read_noise = read_noise[nborder:-nborder, nborder:-nborder]
         darkrate = darkrate[nborder:-nborder, nborder:-nborder]
         gain = gain[nborder:-nborder, nborder:-nborder]
+        linearity = linearity[:, nborder:-nborder, nborder:-nborder]
+        linearity = nonlinearity.NL(linearity)
     else:
         read_noise = galsim.roman.read_noise
         darkrate = galsim.roman.dark_current
         gain = galsim.roman.gain
         flat = 1
+        linearity = None
 
     if rng is None and seed is None:
         seed = 43
@@ -405,12 +416,12 @@ def simulate(metadata, objlist,
         return counts
     l1 = romanisim.l1.make_l1(
         counts, ma_table_number, read_noise=read_noise, rng=rng, gain=gain,
-        **kwargs)
+        linearity=linearity, **kwargs)
     if level == 1:
         im = romanisim.l1.make_asdf(l1, metadata=all_metadata)
     elif level == 2:
         slopeinfo = make_l2(l1, ma_table, read_noise=read_noise,
-                            gain=gain, flat=flat)
+                            gain=gain, flat=flat, linearity=linearity)
         im = make_asdf(*slopeinfo, metadata=all_metadata)
     return im, simcatobj
 

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -96,8 +96,10 @@ def make_l2(resultants, ma_table, read_noise=None, gain=None, flat=None,
 
     from . import ramp
     rampfitter = ramp.RampFitInterpolator(ma_table)
-    ramppar, rampvar = rampfitter.fit_ramps(resultants * gain, read_noise)
+    ramppar, rampvar = rampfitter.fit_ramps(resultants * gain,
+                                            read_noise * gain)
     # could iterate if we wanted to improve the flux estimates
+    # read noise is in counts; must be converted to electrons.
 
     slopes = ramppar[..., 1]
     readvar = rampvar[..., 0, 1, 1]

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -458,13 +458,15 @@ def make_l1(counts, ma_table_number,
     # Those functions call namesakes in galsim.Image which the simple
     # namespace object above doesn't have, with specialized coefficients.
     # We could duplicate that, in principle.
-    log.info('Adding read noise...')
-    resultants = add_read_noise_to_resultants(resultants, tij, rng=rng,
-                                              seed=seed, read_noise=read_noise)
-    # presently in _electrons_ here; is read_noise in ADU or in electrons?!
-    log.warning('We need to make sure we have the right units on the read '
-                'noise.')
 
+    log.info('Adding read noise...')
     resultants /= gain
+    # resultants are now in counts.
+    # read noise is in counts.
+    resultants = add_read_noise_to_resultants(
+        resultants, tij, rng=rng, seed=seed,
+        read_noise=read_noise)
+
+    # quantize
     resultants = np.round(resultants)
     return resultants

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -112,7 +112,6 @@ import galsim
 from . import parameters
 from . import log
 from . import util
-from . import nonlinearity
 
 
 def validate_times(tij):
@@ -271,10 +270,10 @@ def apportion_counts_to_resultants(counts, tij, linearity=None):
             counts_so_far += read
             resultant_counts += counts_so_far
             if linearity is not None:
-                ki_denominator += efficiency*pij_per_read[i][j]
+                ki_denominator += efficiency * pij_per_read[i][j]
             readnum += 1
         resultants[i, ...] = resultant_counts / len(pi)
-    nweirdpixfrac = np.sum(nlflag)/np.product(nlflag.shape)
+    nweirdpixfrac = np.sum(nlflag) / np.product(nlflag.shape)
     if nweirdpixfrac > 0:
         log.warning(f'{nweirdpixfrac:5.1e} fraction of pixels have '
                     'observed(corrected) nonlinearity slopes of >1 or <0.  '

--- a/romanisim/nonlinearity.py
+++ b/romanisim/nonlinearity.py
@@ -8,7 +8,7 @@ absent nonlinearity.  Non-linearity is typically described instead by some
 polynomial that takes the observed number of photons to the corrected number
 of photons.
 
-.. math:: C = f(O) \, ,
+.. math:: C = f(O) \\, ,
 
 where :math:`f` is a polynomial depending on some coefficients that are
 different for each pixel, :math:`C` is the corrected number of photons, and
@@ -102,7 +102,7 @@ def derivative(coeffs):
         raise ValueError('NaNs in nonlinearity coefficients.')
     if np.any(np.all(coeffs == 0, axis=0)):
         raise ValueError('All zero nonlinearity coefficients.')
-    
+
     coeffs = np.array(coeffs)
     derivcoeffs = coeffs * np.arange(0, coeffs.shape[0]).reshape(
         coeffs.shape[0:1] + (1,) * (len(coeffs.shape) - 1))
@@ -139,7 +139,7 @@ def efficiency(counts, derivcoeffs, reversed=False):
     else:
         cc = derivcoeffs[::-1, ...]
     dfdo = np.polyval(cc, counts)
-    return 1/dfdo
+    return 1 / dfdo
 
 
 def correct(counts, coeffs, reversed=False):
@@ -176,7 +176,7 @@ def correct(counts, coeffs, reversed=False):
 
 class NL:
     """Keep track of non-linearity coefficients.
-    
+
     This is a wrapper class to help other classes need to know less
     about non-linearity, but it doesn't presently do much more than
     cache the non-linearity derivative coefficients so that they may be
@@ -217,7 +217,7 @@ class NL:
 
     def correct(self, counts):
         """Compute the correction of observed to true counts
-        
+
         Parameters
         ----------
         counts : np.ndarray[nx, ny] (float)

--- a/romanisim/nonlinearity.py
+++ b/romanisim/nonlinearity.py
@@ -1,0 +1,231 @@
+"""Routines to handle non-linearity in simulating ramps.
+
+As we sample up a ramp, we become decreasingly sensitive to light; given a
+certain number of photons that we would have detected absent nonlinearity,
+we instead detect a smaller number.  In simulations, we want the fraction
+of the number of photons we detect relative to the number we would detect
+absent nonlinearity.  Non-linearity is typically described instead by some
+polynomial that takes the observed number of photons to the corrected number
+of photons.
+
+.. math:: C = f(O) \, ,
+
+where :math:`f` is a polynomial depending on some coefficients that are
+different for each pixel, :math:`C` is the corrected number of photons, and
+:math:`O` is the observed number of photons.
+
+We want instead the current fraction of photons that would be detected in the
+next read.  That's
+
+.. math:: dO/dC = (df/dO)^{-1}
+
+In the context of the up-the-ramp samples performed in the L1 simulations,
+we need to reduce the fraction of photons selected from the binomial
+distribution by this fraction in each read, and then adjust the fraction
+of photons read in in future samples down further to reflect that the
+photons lost to non-linearity will not be read out later down the ramp.
+
+We do some simple sanity checks on the non-linearity coefficients, but we
+do not yet check to make sure that :math:`dO/dC <= 1`.  i.e., we don't yet
+check that the non-linearity correction function corresponds to a curve that
+always means that the number of photons recorded is smaller than the number
+of photons entering the read.  Such cases are likely to cause problems when
+we try to sample more photons from the ramp than were present in the ramp.
+
+The implementation of nonlinearity makes an important simplification:
+that the efficiency is constant within a read.  This isn't quite true.  The
+original implementation in `l1.py` also assumed that the efficiency was equal
+to its value at the start of the read.  Since the efficiency is usually
+dropping as the pixel fills up this leads to the simulation leaving in somewhat
+more photons than expected.  For a particular simulated pixel that I inspected,
+this was a 1% effect at counts = 0 to a 2% effect at counts = 100k, with most
+of the range having a <0.5% effect.  To mitigate this effect, `l1.py` now
+evaluates the efficiency at what it expects the efficiency to be at the middle
+of the read, based on the previous efficiency and the length of the read.  This
+adjustment reduces the bias to <5e-4 across the full range.  The next step would
+be to take this another iteration further, but that feels like overkill.
+"""
+
+import numpy as np
+
+
+def repair_coefficients(coeffs):
+    """Fix cases of zeros and NaNs in non-linearity coefficients.
+
+    This function replaces suspicious-looking non-linearity coefficients with
+    no-op coefficients from a non-linearity perspective; all coefficients are
+    zero except for the linear term, which is set to 1.
+
+    This function doesn't try to make sure that the derivative of the
+    correction is greater than 1, which we would expect for a non-linearity
+    correction.
+
+    Parameters
+    ----------
+    coeffs : np.ndarray[ncoeff, nx, ny] (float)
+        Nonlinearity coefficients, starting with the constant term and
+        increasing in power.
+
+    Returns
+    -------
+    coeffs : np.ndarray[ncoeff, nx, ny] (float)
+        "repaired" coefficients with NaNs and weird coefficients replaced with
+        linear values with slopes of unity.
+    """
+    res = coeffs.copy()
+    nocorrection = np.zeros(coeffs.shape[0], dtype=coeffs.dtype)
+    nocorrection[1] = 1.  # "no correction" is just normal linearity.
+    m = np.any(~np.isfinite(coeffs), axis=0) | np.all(coeffs == 0, axis=0)
+    res[:, m] = nocorrection[:, None]
+    return res
+
+
+def derivative(coeffs):
+    """Compute the coefficients of the derivative of non-linearity corrections.
+
+    The non-linearity corrections are a polynomial; their derivatives are also
+    a polynomial.  This computes those coefficients.
+
+    Parameters
+    ----------
+    coeffs : np.ndarray[ncoeff, nx, ny] (float)
+        Nonlinearity coefficients, starting with the constant term and
+        increasing in power.
+
+    Returns
+    -------
+    derivcoeffs : np.ndarray[ncoeff, nx, ny] (float)
+        coefficients of the polynomial that is the derivative of the
+        non-linearity correction polynomial
+    """
+    if np.any(~np.isfinite(coeffs)):
+        raise ValueError('NaNs in nonlinearity coefficients.')
+    if np.any(np.all(coeffs == 0, axis=0)):
+        raise ValueError('All zero nonlinearity coefficients.')
+    
+    coeffs = np.array(coeffs)
+    derivcoeffs = coeffs * np.arange(0, coeffs.shape[0]).reshape(
+        coeffs.shape[0:1] + (1,) * (len(coeffs.shape) - 1))
+    return derivcoeffs[1:, ...]
+
+
+def efficiency(counts, derivcoeffs, reversed=False):
+    """Convert the (in)efficiency of counting photons due to nonlinearity.
+
+    As photons arrive, they make it harder for the device to count future
+    photons due to classical non-linearity.  The "efficiency" here is the
+    fraction of photons we should count.  It is the reciprocal of the
+    derivative of the correction polynomial.
+
+    Parameters
+    ----------
+    counts : np.ndarray[nx, ny] (float)
+        Number of counts already in pixel
+    derivcoeffs : np.ndarray[ncoeff, nx, ny] (float)
+        Coefficients of the derivative of the non-linearity correction
+        polynomial (e.g., from romanisim.nonlinearity.derivative).
+    reversed : bool
+        If True, the coefficients are in reversed order, which is the
+        order that np.polyval wants them.  One can maybe save a little
+        time reversing them once ahead of time.
+
+    Returns
+    -------
+    efficiencies : np.ndarray[nx, ny] (float)
+        The (instantaneous) fraction of arriving photons that will be counted.
+    """
+    if reversed:
+        cc = derivcoeffs
+    else:
+        cc = derivcoeffs[::-1, ...]
+    dfdo = np.polyval(cc, counts)
+    return 1/dfdo
+
+
+def correct(counts, coeffs, reversed=False):
+    """Correct the observed counts for non-linearity.
+
+    As photons arrive, they make it harder for the device to count
+    future photons due to classical non-linearity.  This function
+    converts some observed counts to what would have been seen absent
+    non-linearity given some non-linearity corrections described by
+    polynomials with given coefficients.
+
+    Parameters
+    ----------
+    counts : np.ndarray[nx, ny] (float)
+        Number of counts already in pixel
+    coeffs : np.ndarray[ncoeff, nx, ny] (float)
+        Coefficients of the non-linearity correction polynomials
+    reversed : bool
+        If True, the coefficients are in reversed order, which is the
+        order that np.polyval wants them.  One can maybe save a little
+        time reversing them once ahead of time.
+
+    Returns
+    -------
+    corrected : np.ndarray[nx, ny] (float)
+        The corrected number of counts
+    """
+    if reversed:
+        cc = coeffs
+    else:
+        cc = coeffs[::-1, ...]
+    return np.polyval(cc, counts)
+
+
+class NL:
+    """Keep track of non-linearity coefficients.
+    
+    This is a wrapper class to help other classes need to know less
+    about non-linearity, but it doesn't presently do much more than
+    cache the non-linearity derivative coefficients so that they may be
+    used multiple times in the up-the-ramp sampling.
+
+    It would be nice to encapsulate more information about the loss of
+    photons up the read that is presently in `l1.py`, but that's pretty
+    tightly coupled to the apportionment mechanism and so I haven't
+    explored that adequately.
+    """
+    def __init__(self, coeffs):
+        """Construct an NL class handling non-linearity correction.
+
+        Parameters
+        ----------
+        coeffs : np.ndarray[ncoeff, nx, ny] (float)
+            Non-linearity coefficients from reference files.
+        """
+        self.coeffs = repair_coefficients(coeffs)
+        self.derivcoeffs = derivative(self.coeffs)
+        self.coeffs = self.coeffs[::-1, ...].copy()
+        self.derivcoeffs = self.derivcoeffs[::-1, ...].copy()
+
+    def efficiency(self, counts):
+        """Compute the efficiency of photon counting given a count level.
+
+        Parameters
+        ----------
+        counts : np.ndarray[nx, ny] (float)
+            The counts in each pixel
+
+        Returns
+        -------
+        efficiency : np.ndarray[nx, ny] (float)
+            The efficiency of each pixel at the current count level.
+        """
+        return efficiency(counts, self.derivcoeffs, reversed=True)
+
+    def correct(self, counts):
+        """Compute the correction of observed to true counts
+        
+        Parameters
+        ----------
+        counts : np.ndarray[nx, ny] (float)
+            The observed counts
+
+        Returns
+        -------
+        corrected : np.ndarray[nx, ny] (float)
+            The corrected counts.
+        """
+        return correct(counts, self.coeffs, reversed=True)

--- a/romanisim/nonlinearity.py
+++ b/romanisim/nonlinearity.py
@@ -26,7 +26,7 @@ of photons read in in future samples down further to reflect that the
 photons lost to non-linearity will not be read out later down the ramp.
 
 We do some simple sanity checks on the non-linearity coefficients, but we
-do not yet check to make sure that :math:`dO/dC <= 1`.  i.e., we don't yet
+do not yet check to make sure that :math:`dO/dC \\leq 1`.  i.e., we don't yet
 check that the non-linearity correction function corresponds to a curve that
 always means that the number of photons recorded is smaller than the number
 of photons entering the read.  Such cases are likely to cause problems when

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -191,15 +191,11 @@ class GWCS(galsim.wcs.CelestialWCS):
         if np.ndim(x) == np.ndim(y) == 0:
             return r[0], d[0]
         else:
-            if ((np.ndim(x) == np.ndim(y)) and (x.shape == y.shape)):
-                return r, d
-            else:
-                if (np.ndim(x) != np.ndim(y)):
-                    raise ValueError(f"np.ndim(x) != np.ndim(y) => {np.ndim(x)} != {np.ndim(y)}")
-                elif (x.shape != y.shape):
-                    raise ValueError(f"x.shape != y.shape => {x.shape} != {y.shape}")
-                else:
-                    raise ValueError("Invalid x & y.")
+            if (np.ndim(x) != np.ndim(y)):
+                raise ValueError(f"np.ndim(x) != np.ndim(y) => {np.ndim(x)} != {np.ndim(y)}")
+            elif (x.shape != y.shape):
+                raise ValueError(f"x.shape != y.shape => {x.shape} != {y.shape}")
+            return r, d
 
     def _xy(self, ra, dec, color=None):
         # _xy accepts ra/dec in radians; we decorate r1, d1 appropriately.
@@ -217,8 +213,7 @@ class GWCS(galsim.wcs.CelestialWCS):
                 raise ValueError(f"np.ndim(ra) != np.ndim(dec) => {np.ndim(ra)} != {np.ndim(dec)}")
             elif (x.shape != y.shape):
                 raise ValueError(f"ra.shape != dec.shape => {ra.shape} != {dec.shape}")
-            else:
-                raise ValueError("Invalid ra & dec.")
+            return x, y
 
     def _newOrigin(self, origin):
         ret = self.copy()

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -151,10 +151,6 @@ def make_wcs(targ_pos, roll_ref, distortion, wrap_v2_at=180, wrap_lon_at=360):
 class GWCS(galsim.wcs.CelestialWCS):
     """This WCS uses gWCS to implent a galsim CelestialWCS.
 
-    GWCS is initialized via
-
-       >>> wcs = romanisim.wcs.GWCS(gwcs)
-
     Based on galsim.fitswcs.AstropyWCS, edited to eliminate header functionality
     and to adopt the shared API supported by both gWCS and astropy.wcs.
 


### PR DESCRIPTION
This adds a new module that handles classical non-linearity.

There's some complexity needed to handle both images that already include poisson noise (e.g., from galsim's photon shooting rendering approach) and non-linearity.  That took a while to get right but ends up not being very expensive.  There is documentation in the l1 documentation and modules.

Also fix a bug in the updated exception logic in GWCS._xy that was preventing any images from being made when using CRDS.