### PR TITLE
Add IPC.

### DIFF
--- a/docs/romanisim/l1.rst
+++ b/docs/romanisim/l1.rst
@@ -23,5 +23,12 @@ To address (1), we adjust the probability of the number of counts we draw from t
 
 Note that this picture of nonlinearity is that the pixels are not recording all of the photons in the presence of nonlinearity.  Another picture is that the effective gain changes---i.e., the relationship between recorded counts and photons---but that the Poisson statistics on the number of photons should be consistent with having counted all of the photons.  That's not what the code is doing at the moment, though it's straightforward.
 
+Interpixel Capacitance
+----------------------
+
+Interpixel capacitance (IPC) is added following non-linearity and before read-out.  Read noise remains independent among different pixels but the Poisson noise is correlated between pixels by the IPC.  We simply convolve the resultants by a 3x3 kernel after apportioning counts to resultants and applying non-linearity but before adding read noise.
+
+This is slightly different than including IPC in the PSF kernel because including IPC in the PSF kernel leaves the Poisson noise uncorrelated.
+
 .. automodapi:: romanisim.l1
 .. automodapi:: romanisim.nonlinearity

--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -31,7 +31,7 @@ read_time = 3.04
 # following kernel, 0.2% of the flux is redistributed to the pixel
 # that is +1 - N spaces ahead in memory.
 ipc_kernel = np.array(
-    [[ 0.21,  1.66,  0.22],
-     [ 1.88, 91.59,  1.87],
-     [ 0.21,  1.62,  0.2 ]])
+    [[0.21, 1.66, 0.22],
+     [1.88, 91.59, 1.87],
+     [0.21, 1.62, 0.2]])
 ipc_kernel /= np.sum(ipc_kernel)

--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -1,6 +1,9 @@
 """Parameters class storing a few useful constants for Roman simulations.
 """
 
+import numpy as np
+
+
 default_parameters_dictionary = {
     'roman.meta.instrument.name': 'WFI',
     'roman.meta.instrument.detector': 'WFI07',
@@ -21,3 +24,14 @@ nborder = 4  # number of border pixels used for reference pixels.
 ma_table = {1: [[1, 8], [9, 8], [17, 8], [25, 8], [33, 8], [41, 8]]}
 
 read_time = 3.04
+
+# from draft wfisim documentation
+# assumed to be compatible in direction with scipy.ndimage.convolve.
+# this is consistent with Andrea Bellini's convention, where, in the
+# following kernel, 0.2% of the flux is redistributed to the pixel
+# that is +1 - N spaces ahead in memory.
+ipc_kernel = np.array(
+    [[ 0.21,  1.66,  0.22],
+     [ 1.88, 91.59,  1.87],
+     [ 0.21,  1.62,  0.2 ]])
+ipc_kernel /= np.sum(ipc_kernel)


### PR DESCRIPTION
Add a simple IPC implementation.

The interpixel capacitance kernel is currently hard-coded in `romanisim.parameters.ipc_kernel`.  We'd rather grab that from CRDS when it becomes available, but that's a straightforward addition.

Convolution with the IPC kernel is done after the idealized photons have been assigned to reads but before read noise has been applied, correlating the Poisson noise while leaving the read noise independent.

Presumably the values of the reference pixels talk to the science pixels slightly through IPC.  That's not modeled here and will result in a slight error for the outside row of pixels.  The treatment here isn't terrible, though; the reference pixels are treated as having zero flux, and in fact they will have much less flux than the science pixels.

Getting the conventions right on the IPC kernel can be tricky.  The convention we're using is that a delta function is spread out by IPC in the image in a way that looks like the IPC kernel.  One also needs to think about things like fortran vs. python array layouts, but they turn out to match up in the end, so that our convention matches wfisim's.