### PR TITLE
Fix codecov badge (master -> main).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/spacetelescope/romanisim/actions/workflows/ci.yml/badge.svg)](https://github.com/spacetelescope/romanisim/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/spacetelescope/romanisim/branch/master/graph/badge.svg?token=pkoLtQOa2v)](https://codecov.io/gh/spacetelescope/romanisim)
+[![CI](https://github.com/spacetelescope/romanisim/actions/workflows/ci.yml/badge.svg)](https://github.com/spacetelescope/romanisim/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/spacetelescope/romanisim/branch/main/graph/badge.svg?token=pkoLtQOa2v)](https://codecov.io/gh/spacetelescope/romanisim)
 
 # romanisim: an image simulator for Roman
 


### PR DESCRIPTION
The code coverage badge had a dangling reference to master; this has been replaced with main.