### PR TITLE
Add unit tests for L1 module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
       - run: echo "DATA_PATH=$HOME/work/romanisim/romanisim/romanisim/data" >> $GITHUB_ENV
       - run: |
-          wget https://stsci.box.com/shared/static/963l3m4hcrpc29bqxq68ilcsfgfqwiyc.gz -O ${{ env.DATA_PATH }}/minimal-webbpsf-data.tar.gz
+          wget https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz -O ${{ env.DATA_PATH }}/minimal-webbpsf-data.tar.gz
           cd ${{ env.DATA_PATH }}
           tar -xzvf minimal-webbpsf-data.tar.gz
           mkdir galsim-data

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -109,7 +109,6 @@ going to pursue this avenue further.
 import numpy as np
 import asdf
 import galsim
-from galsim import roman
 from scipy import ndimage
 from . import parameters
 from . import log

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -347,7 +347,9 @@ def make_asdf(resultants, filepath=None, metadata=None):
     """
 
     from roman_datamodels.testing.utils import mk_level1_science_raw
-    out = mk_level1_science_raw(shape=(len(resultants), 4096, 4096))
+    nborder = parameters.nborder
+    npix = galsim.roman.n_pix + 2 * nborder
+    out = mk_level1_science_raw(shape=(len(resultants), npix, npix))
     if metadata is not None:
         tmpmeta = util.flatten_dictionary(out['meta'])
         tmpmeta.update(util.flatten_dictionary(

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -109,6 +109,7 @@ going to pursue this avenue further.
 import numpy as np
 import asdf
 import galsim
+from galsim import roman
 from scipy import ndimage
 from . import parameters
 from . import log
@@ -353,7 +354,6 @@ def make_asdf(resultants, filepath=None, metadata=None):
         tmpmeta.update(util.flatten_dictionary(
             util.unflatten_dictionary(metadata)['roman']['meta']))
         out['meta'].update(util.unflatten_dictionary(tmpmeta))
-    nborder = parameters.nborder
     out['data'][:, nborder:-nborder, nborder:-nborder] = resultants
     if filepath:
         af = asdf.AsdfFile()
@@ -392,7 +392,7 @@ def ma_table_to_tij(ma_table_number):
 
 
 def make_l1(counts, ma_table_number,
-            read_noise=None, filepath=None, rng=None, seed=None,
+            read_noise=None, rng=None, seed=None,
             gain=None, linearity=None):
     """Make an L1 image from a counts image.
 
@@ -408,8 +408,6 @@ def make_l1(counts, ma_table_number,
     ma_table_number : int
         multi accum table number indicating how reads are apportioned among
         resultants
-    filepath : str or None
-        optional, path to which to write out L1 image
     read_noise : np.ndarray[nx, ny] (float) or float
         Read noise entering into each read
     rng : galsim.BaseDeviate
@@ -453,7 +451,8 @@ def make_l1(counts, ma_table_number,
                                   mode='constant', cval=0)
 
     log.info('Adding read noise...')
-    resultants /= gain
+    if gain is not None:
+        resultants /= gain
     # resultants are now in counts.
     # read noise is in counts.
     resultants = add_read_noise_to_resultants(

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -1,0 +1,108 @@
+"""Unit tests for L1 module.
+
+Routines tested:
+- validate_times
+- tij_to_pij
+- apportion_counts_to_resultants
+- add_read_noise_to_resultants
+- make_asdf
+- ma_table_to_tij
+- make_l1
+"""
+
+import numpy as np
+from romanisim import l1
+import galsim
+import galsim.roman
+import asdf
+
+tijlist = [
+    [[1], [2, 3], [4, 5], [6, 7]],
+    [[100], [101, 102, 103], [110]],
+    [[1], [2], [3, 4, 5, 100]],
+    ]
+
+ma_table_list = [
+    [[1, 10], [11, 1], [12, 10], [30, 1], [40, 5], [50, 100]],
+    [[1, 1]],
+    [[1, 1], [10, 1]],
+]
+
+def test_validate_times():
+    assert l1.validate_times([[0, 1], [2, 3, 4], [5, 6, 7, 8], [9], [10]])
+    assert l1.validate_times([[-1, 0], [10, 11], [12, 20], [100]])
+    assert not l1.validate_times([[0, 0], [1, 2], [3, 4]])
+    assert not l1.validate_times([[0, 1], [1, 2], [3, 4]])
+    assert not l1.validate_times([[0, -1], [1, 2], [3, 4]])
+
+
+def test_tij_to_pij():
+    for tij in tijlist:
+        pij = l1.tij_to_pij(tij, remaining=True)
+        pij = np.concatenate(pij)
+        assert pij[-1] == 1
+        assert np.all(pij > 0)
+        assert np.all(pij <= 1)
+        pij = l1.tij_to_pij(tij)
+        pij = np.concatenate(pij)
+        assert np.all(pij > 0)
+        assert np.all(pij <= 1)
+        assert np.allclose(
+            pij, np.diff(np.concatenate(tij), prepend=0)/tij[-1][-1])
+        
+
+
+def test_apportion_counts_to_resultants():
+    # we'll skip the linearity tests until new linearity files with
+    # inverse coefficients are available in CRDS.
+    counts = np.random.poisson(100, size=(100, 100))
+    read_noise = 10
+    for tij in tijlist:
+        resultants = l1.apportion_counts_to_resultants(counts, tij)
+        assert np.all(np.diff(resultants, axis=0) >= 0)
+        assert np.all(resultants >= 0)
+        assert np.all(resultants <= counts[None, :, :])
+        res2 = l1.add_read_noise_to_resultants(resultants.copy(), tij)
+        res3 = l1.add_read_noise_to_resultants(resultants.copy(), tij,
+                                               read_noise=read_noise)
+        assert np.all(res2 != resultants)
+        assert np.all(res3 != resultants)
+        for restij, plane_index in zip(tij, np.arange(res3.shape[0])):
+            sdev = np.std(res3[plane_index] - resultants[plane_index])
+            assert (sdev - read_noise / np.sqrt(len(restij))
+                    < 20 * sdev / np.sqrt(2 * len(counts.ravel())))
+    
+def test_ma_table_to_tij():
+    tij = l1.ma_table_to_tij(1)
+    # this is the only numbered ma_table that we have presently provided.
+    assert l1.validate_times(tij)
+    for ma_table in ma_table_list:
+        tij = l1.ma_table_to_tij(ma_table)
+        assert l1.validate_times(tij)
+    
+
+def test_make_l1_and_asdf(tmp_path):
+    # these two functions basically just wrap the above and we'll really
+    # just test for sanity.
+    counts = np.random.poisson(100, size=(100, 100))
+    galsim.roman.n_pix = 100
+    for ma_table in ma_table_list:
+        resultants = l1.make_l1(galsim.Image(counts), ma_table, gain=1)
+        assert resultants.shape[0] == len(ma_table)
+        assert resultants.shape[1] == counts.shape[0]
+        assert resultants.shape[2] == counts.shape[1]
+        # these contain read noise and shot noise, so it's not
+        # clear what else to do with them?
+        assert np.all(resultants == resultants.astype('i4'))
+        # we could look for non-zero correlations from the IPC to
+        # check that that is working?  But that is slightly annoying.
+        resultants = l1.make_l1(galsim.Image(counts), ma_table, read_noise=0)
+        assert np.all(resultants <= np.max(counts[None, ...]))
+        # because of IPC, one can't require that each pixel is smaller
+        # than the number of counts
+        assert np.all(resultants >= 0)
+        assert np.all(np.diff(resultants, axis=0) >= 0)
+        res_forasdf = l1.make_asdf(resultants, filepath=tmp_path / 'tmp.asdf')
+        af = asdf.AsdfFile()
+        af.tree = {'roman': res_forasdf}
+        af.validate()

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -20,13 +20,14 @@ tijlist = [
     [[1], [2, 3], [4, 5], [6, 7]],
     [[100], [101, 102, 103], [110]],
     [[1], [2], [3, 4, 5, 100]],
-    ]
+]
 
 ma_table_list = [
     [[1, 10], [11, 1], [12, 10], [30, 1], [40, 5], [50, 100]],
     [[1, 1]],
     [[1, 1], [10, 1]],
 ]
+
 
 def test_validate_times():
     assert l1.validate_times([[0, 1], [2, 3, 4], [5, 6, 7, 8], [9], [10]])
@@ -48,8 +49,7 @@ def test_tij_to_pij():
         assert np.all(pij > 0)
         assert np.all(pij <= 1)
         assert np.allclose(
-            pij, np.diff(np.concatenate(tij), prepend=0)/tij[-1][-1])
-        
+            pij, np.diff(np.concatenate(tij), prepend=0) / tij[-1][-1])
 
 
 def test_apportion_counts_to_resultants():
@@ -71,7 +71,8 @@ def test_apportion_counts_to_resultants():
             sdev = np.std(res3[plane_index] - resultants[plane_index])
             assert (sdev - read_noise / np.sqrt(len(restij))
                     < 20 * sdev / np.sqrt(2 * len(counts.ravel())))
-    
+
+
 def test_ma_table_to_tij():
     tij = l1.ma_table_to_tij(1)
     # this is the only numbered ma_table that we have presently provided.
@@ -79,7 +80,7 @@ def test_ma_table_to_tij():
     for ma_table in ma_table_list:
         tij = l1.ma_table_to_tij(ma_table)
         assert l1.validate_times(tij)
-    
+
 
 def test_make_l1_and_asdf(tmp_path):
     # these two functions basically just wrap the above and we'll really


### PR DESCRIPTION
This PR adds unit tests for the L1 module.  This module is pretty well self-contained and testing works out without any surprises.  There were a couple of minor improvements as well, allowing the L1 module to simulate images that aren't 4k x 4k (to speed tests), and to optionally not use gain measurements.  A few unused vestigial arguments were also removed.

I could not think of especially good tests of correctness.  Even reasonable things like "ramps increase" or "ramps don't measure more photons in total than were accumulated in the whole exposure" aren't true because of read noise.  I turn off read noise and do some basic tests, and then turn it back on and just do sanity tests (... is the shape right?), as well as testing that the read noise applied looks like what one would expect.

It would be virtuous to check that the correlations between reads are what one would expect given the Poisson noise covariances.  I have played that game before but am not presently playing it as part of the unit tests.  I could consider adding that in a later PR but don't want to focus on it now.