### PR TITLE
Fix units of dark rate.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
       - run: echo "DATA_PATH=$HOME/work/romanisim/romanisim/romanisim/data" >> $GITHUB_ENV
       - run: |
-          wget https://stsci.box.com/shared/static/963l3m4hcrpc29bqxq68ilcsfgfqwiyc.gz -O ${{ env.DATA_PATH }}/minimal-webbpsf-data.tar.gz
+          wget https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz -O ${{ env.DATA_PATH }}/minimal-webbpsf-data.tar.gz
           cd ${{ env.DATA_PATH }}
           tar -xzvf minimal-webbpsf-data.tar.gz
           mkdir galsim-data

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -74,7 +74,7 @@ def make_l2(resultants, ma_table, read_noise=None, gain=None, flat=None,
     linearity : romanisim.nonlinearity.NL object or None
         non-linearity correction to use.
     dark : np.ndarray[nresultants, nx, ny] (float)
-        dark current image to subtract from ramps
+        dark image to subtract from ramps (DN)
 
     Returns
     -------
@@ -401,6 +401,7 @@ def simulate(metadata, objlist,
         gain = gain[nborder:-nborder, nborder:-nborder]
         linearity = linearity[:, nborder:-nborder, nborder:-nborder]
         linearity = nonlinearity.NL(linearity)
+        darkrate *= gain
     else:
         read_noise = galsim.roman.read_noise
         darkrate = galsim.roman.dark_current

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -392,8 +392,8 @@ def simulate(metadata, objlist,
 
         # convert the last dark resultant into a dark rate by dividing by the
         # mean time in that resultant.
-        darkrate = dark[-1] / (
-            (ma_table[-1][0] + (ma_table[-1][1] - 1) / 2) * parameters.read_time)
+        darkrate = dark[-1] / parameters.read_time / (
+            (ma_table[-1][0] + (ma_table[-1][1] - 1) / 2))
         nborder = parameters.nborder
         read_noise = read_noise[nborder:-nborder, nborder:-nborder]
         darkrate = darkrate[nborder:-nborder, nborder:-nborder]


### PR DESCRIPTION
The dark rate is supposed to be in electrons / s, but it was formerly in DN / s.  Multiplying by the gain addresses this issue.