### PR TITLE
Add SOC tests for DMS 214, 215, 216 (image rendering)

### DIFF
--- a/docs/romanisim/bandpass.rst
+++ b/docs/romanisim/bandpass.rst
@@ -5,4 +5,6 @@ The simulator can render scenes in a number of different bandpasses.  The choice
 
 At present, romanisim simply passes the choice of bandpass to other packages---to webbpsf for PSF modeling, to galsim.roman for sky background estimation, to CRDS for reference file selection, or to the catalog for the selection of appropriate fluxes.  However, because catalog fluxes are specified in "maggies" (i.e., in linear fluxes on the AB scale), the simulator needs to know how to convert between a maggie and the number of photons Roman receives from a source.  Accordingly, the simulator knows about the AB zero points of the Roman filters, as derived from https://roman.gsfc.nasa.gov/science/WFI_technical.html .
 
+One technical note: it is unclear what aperture is used for the bandpasses provided by Goddard.  The Roman PSF formally extends to infinity and some light is received by the detector but is so far from the center of the PSF that it is not useful for flux, position, or shape measurements.  Often for the purposes of computing effective area curves only light landing within a fixed aperture is counted.  Presently the simulator assumes that an infinite aperture is used.  This can result in an approximately 10% different flux scale than more reasonable aperture selections.
+
 .. automodapi:: romanisim.bandpass

--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -20,7 +20,6 @@ should consider the following:
 
 """
 
-import numpy as np
 import galsim
 from galsim import roman
 from .bandpass import galsim2roman_bandpass, roman2galsim_bandpass

--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -78,19 +78,9 @@ def make_psf(sca, filter_name, wcs=None, webbpsf=True, pix=None,
     wfi.filter = filter_name
     wfi.detector_position = pix
     oversample = kw.get('oversample', 4)
+    # webbpsf doesn't do distortion
     psf = wfi.calc_psf(oversample=oversample)
-    if wcs is None:
-        scale = 0.11
-    else:
-        # get the actual pixel scale from the WCS
-        # we really should do better here, aiming to get the full
-        # CD matrix.
-        # We can't just use wcs since it doesn't have the oversampling.
-        cen = wcs.toWorld(galsim.PositionD(*pix))
-        p1 = wcs.toWorld(galsim.PositionD(pix[0] + 1, pix[1]))
-        p2 = wcs.toWorld(galsim.PositionD(pix[0], pix[1] + 1))
-        scale = np.sqrt(cen.distanceTo(p1).deg * 60 * 60 * cen.distanceTo(p2).deg * 60 * 60)
     intimg = galsim.InterpolatedImage(
-        galsim.Image(psf[0].data, scale=scale / oversample),
+        galsim.Image(psf[0].data, scale=wfi.pixelscale / oversample),
         normalization='flux')
     return intimg

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -25,6 +25,7 @@ import asdf
 import webbpsf
 from astropy.modeling.functional_models import Sersic2D
 import pytest
+from romanisim import log
 
 
 def test_in_bounds():
@@ -154,6 +155,8 @@ def test_image_rendering():
 
     # DMS214 - our PSF matches that from WebbPSF
     assert np.max(np.abs((cenim - cenpsfim) / cenunc)) < 5
+    log.info('DMS214: rendered PSF matches WebbPSF')
+
     # 5 sigma isn't so bad.
     # largest difference is in the center pixel, ~1.5%.  It seems to me that
     # this is from the simple oversampling-based integration; galsim should
@@ -216,6 +219,10 @@ def test_image_rendering():
 
     # DMS 215
     assert np.max(np.abs((cenim - cenmodim) / cenunc)) < 5
+    log.info('DMS215: rendered galaxy matches astropy Sersic2D after '
+             'pixel integration.')
+
+
     # our two different realizations of this PSF convolved model
     # Sersic galaxy agree at <5 sigma on all pixels using only
     # Poisson errors and containing 100k counts.
@@ -368,7 +375,7 @@ def test_simulate(tmp_path):
     af.tree = {'roman': res}
     # DMS216
     af.validate()
-
+    log.info('DMS216: successfully made a L2 file.')
 
 def test_make_catalog_and_images():
     # this isn't a real routine that we should consider part of the

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -222,7 +222,6 @@ def test_image_rendering():
     log.info('DMS215: rendered galaxy matches astropy Sersic2D after '
              'pixel integration.')
 
-
     # our two different realizations of this PSF convolved model
     # Sersic galaxy agree at <5 sigma on all pixels using only
     # Poisson errors and containing 100k counts.
@@ -376,6 +375,7 @@ def test_simulate(tmp_path):
     # DMS216
     af.validate()
     log.info('DMS216: successfully made a L2 file.')
+
 
 def test_make_catalog_and_images():
     # this isn't a real routine that we should consider part of the


### PR DESCRIPTION
This adds tests demonstrating PSF rendering, analytic model galaxy rendering, and L2 image creation.

This decorates an existing test that made an image in L2 format, and additionally makes some new image rendering tests, intending to demonstrate that we successfully put PSFs and galaxies in images.  I have tried to make these tests non-trivial by avoiding using galsim to do the rendering, and instead doing my own dumb brute force rendering techniques---basically just rendering the images in a hugely oversampled way and then binning down.  I then verify that the inner few arcseconds of the resulting images agree at the 5 sigma level, including only Poisson errors, for sources with 100k total counts. Agreement is quite good, though there are small differences everywhere due to the imperfect integration over pixels and different treatment of the extreme wings of the PSF where there is no flux.

The tests identified a few issues which were also addressed:
- we formerly did object.withFlux(...) on the convolved object, and now do it on the source profile.  The difference is that the PSF profile may not sum to 1 exactly, as it contains only an image of the PSF in a finite aperture.  This leads to a change in the flux scale of ~2%.
- Before we were unintentionally using a convention where pixel 1 is the center of the first pixel; now pixel 0 is the center of the first pixel.  This now matches the pixel_to_world convention used by GWCS and inherited here.
- I previously believed that webbpsf contained distortion in its modeling, but it does not.  This simplifies construction of the PSF slightly.