### PR TITLE
Changes supporting adding tests for uncalibrated image simulation

### DIFF
--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -15,7 +15,11 @@ from . import util
 
 @dataclasses.dataclass
 class CatalogObject:
-    """Simple class to hold galsim positions and profiles of objects."""
+    """Simple class to hold galsim positions and profiles of objects.
+
+    Flux element contains the total AB flux from the source; i.e., the
+    -2.5*log10(flux[filter_name]) would be the AB magnitude of the source.
+    """
     sky_pos: galsim.CelestialCoord
     profile: galsim.GSObject
     flux: dict
@@ -174,7 +178,6 @@ def make_dummy_table_catalog(coord, radius=0.1, rng=None, nobj=1000,
         # sigma of one mag isn't nuts.  But this will be totally uncorrelated
         # in different bands, so we'll get some weird colored objects
         out[bandpass] = 10.**(-mag_thisband / 2.5)
-        # maggies!  what units should I actually pick here?
     return out
 
 

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -10,6 +10,7 @@ import numpy as np
 import astropy.time
 from astropy import units as u
 from astropy import coordinates
+from astropy import table
 import asdf
 import galsim
 from galsim import roman
@@ -100,6 +101,7 @@ def make_l2(resultants, ma_table, read_noise=None, gain=None, flat=None,
         resultants = resultants - dark
 
     from . import ramp
+    log.info('Fitting ramps.')
     rampfitter = ramp.RampFitInterpolator(ma_table)
     ramppar, rampvar = rampfitter.fit_ramps(resultants * gain,
                                             read_noise * gain)
@@ -120,7 +122,7 @@ def make_l2(resultants, ma_table, read_noise=None, gain=None, flat=None,
 
 
 def in_bounds(xx, yy, imbd, margin):
-    """Filter sources in an objlist to those landing on an image.
+    """Filter sources to those landing on an image.
 
     Parameters
     ----------
@@ -208,10 +210,9 @@ def add_objects_to_image(image, objlist, xpos, ypos, psf,
         profile = obj.profile
         if not chromatic:
             if obj.flux is None:
-                raise ValueError('Non-crhomatic sources must have specified '
+                raise ValueError('Non-chromatic sources must have specified '
                                  'fluxes!')
-            profile = profile.withFlux(
-                obj.flux[filter_name] * flux_to_counts_factor)
+            profile = profile.withFlux(obj.flux[filter_name])
         final = galsim.Convolve(profile * flux_to_counts_factor, psf)
         if chromatic:
             stamp = final.drawImage(
@@ -236,6 +237,21 @@ def add_objects_to_image(image, objlist, xpos, ypos, psf,
     return outinfo
 
 
+def trim_objlist(objlist, image):
+    cc = coordinates.SkyCoord(
+        objlist['ra'] * u.deg, objlist['dec'] * u.deg)
+    center = image.wcs._radec(
+        image.array.shape[0] // 2, image.array.shape[1] // 2)
+    center = coordinates.SkyCoord(*np.array(center) * u.rad)
+    corner = image.wcs._radec(0, 0)
+    corner = coordinates.SkyCoord(*np.array(corner) * u.rad)
+    sep = center.separation(cc)
+    maxsep = 1.1 * corner.separation(center)  # 10% buffer
+    keep = sep < maxsep
+    objlist = objlist[keep]
+    return objlist
+
+
 def simulate_counts_generic(image, exptime, objlist=None, psf=None,
                             zpflux=None,
                             sky=None, dark=None,
@@ -254,8 +270,8 @@ def simulate_counts_generic(image, exptime, objlist=None, psf=None,
     Then there are a few of individual components that can be added on to
     an image:
 
-    * objlist: a list of CatalogObjects to render.  Can be chromatic or not.
-      This will have all your normal PSF and galaxy profiles.
+    * objlist: a list of CatalogObjects to render, or a Table.  Can be chromatic
+      or not.  This will have all your normal PSF and galaxy profiles.
     * sky: a sky background model.  This is different from a dark in that
       it is sensitive to the flat field.
     * dark: a dark model.
@@ -267,7 +283,7 @@ def simulate_counts_generic(image, exptime, objlist=None, psf=None,
         Image onto which other effects should be added, with associated WCS.
     exptime : float
         Exposure time
-    objlist : list[CatalogObject] or None
+    objlist : list[CatalogObject], Table, or None
         Sources to render
     psf : galsim.Profile
         PSF to use when rendering sources
@@ -304,15 +320,20 @@ def simulate_counts_generic(image, exptime, objlist=None, psf=None,
     if rng is None:
         rng = galsim.UniformDeviate(seed)
     if (objlist is not None and len(objlist) > 0
-            and wcs is None and (xpos is None or ypos is None)):
+            and image.wcs is None and (xpos is None or ypos is None)):
         raise ValueError('xpos and ypos must be set if rendering objects '
                          'without a WCS.')
     if objlist is None:
         objlist = []
     if len(objlist) > 0 and xpos is None:
-        coord = np.array([[o.sky_pos.ra.rad, o.sky_pos.dec.rad]
-                          for o in objlist])
-        xpos, ypos = image.wcs._xy(coord[:, 0], coord[:, 1])
+        if isinstance(objlist, table.Table):
+            objlist = trim_objlist(objlist, image)
+            xpos, ypos = image.wcs._xy(
+                np.radians(objlist['ra']), np.radians(objlist['dec']))
+        else:
+            coord = np.array([[o.sky_pos.ra.rad, o.sky_pos.dec.rad]
+                             for o in objlist])
+            xpos, ypos = image.wcs._xy(coord[:, 0], coord[:, 1])
         # use private vectorized transformation
     if xpos is not None:
         xpos = np.array(xpos)
@@ -322,6 +343,11 @@ def simulate_counts_generic(image, exptime, objlist=None, psf=None,
         keep = in_bounds(xpos, ypos, image.bounds, ignore_distant_sources)
     else:
         keep = []
+    if (len(objlist) > 0) and isinstance(objlist, table.Table):
+        objlist = catalog.table_to_catalog(objlist[keep], [filter_name])
+        xpos = xpos[keep]
+        ypos = ypos[keep]
+        keep = np.ones(len(objlist), dtype='bool')
     if len(objlist) > 0 and psf is None:
         raise ValueError('Must provide a PSF if you want to render objects.')
 
@@ -406,7 +432,7 @@ def simulate_counts(sca, targ_pos, date, objlist, filter_name,
         Location on sky to observe; telescope boresight
     date : astropy.time.Time
         Time at which to simulate observation
-    objlist : list[CatalogObject]
+    objlist : list[CatalogObject] or Table
         Objects to simulate
     filter_name : str
         Roman filter bandpass to use
@@ -447,7 +473,9 @@ def simulate_counts(sca, targ_pos, date, objlist, filter_name,
     bandpass = roman.getBandpasses(AB_zeropoint=True)[galsim_filter_name]
     imwcs = wcs.get_wcs(world_pos=targ_pos, date=date, sca=sca, usecrds=usecrds)
     chromatic = False
-    if len(objlist) > 0 and objlist[0].profile.spectral:
+    if (len(objlist) > 0
+            and not isinstance(objlist, table.Table)  # this case is always gray
+            and objlist[0].profile.spectral):
         chromatic = True
     psf = romanisim.psf.make_psf(sca, filter_name, wcs=imwcs,
                                  chromatic=chromatic, webbpsf=webbpsf)
@@ -488,7 +516,7 @@ def simulate(metadata, objlist,
         * bandpass: metadata['instrument']['optical_detector']
         * ma_table_number: metadata['exposure']['ma_table_number']
 
-    objlist : list[CatalogObject]
+    objlist : list[CatalogObject] or Table
         List of objects in the field to simulate
     usecrds : bool
         use CRDS to get distortion maps
@@ -596,6 +624,7 @@ def simulate(metadata, objlist,
                             gain=gain, flat=flat, linearity=linearity,
                             dark=dark)
         im = make_asdf(*slopeinfo, metadata=all_metadata)
+    log.info('Simulation complete.')
     return im, simcatobj
 
 

--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -35,3 +35,5 @@ ipc_kernel = np.array(
      [1.88, 91.59, 1.87],
      [0.21, 1.62, 0.2]])
 ipc_kernel /= np.sum(ipc_kernel)
+
+v2v3_wficen = (1546.3846181707652, -892.7916365721071)

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -246,6 +246,11 @@ def test_add_objects():
     peaklocs = np.where(im.array == np.max(im.array))
     peakloc = peaklocs[1][0] + im.bounds.xmin, peaklocs[0][0] + im.bounds.ymin
     assert (peakloc[0] == 60) & (peakloc[1] == 30)
+    im.array[:] = 0
+    image.add_objects_to_image(im, chromcatalog, [60, 60], [30, 30],
+                               impsfchromatic, flux_to_counts_factor=2,
+                               bandpass=bandpass)
+    assert (np.abs(np.sum(im.array) - 2 * counts * 2) < 40 * np.sqrt(counts))
 
 
 def test_simulate_counts_generic():

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -17,10 +17,11 @@ import os
 import numpy as np
 import galsim
 from galsim import roman
-from romanisim import image, parameters, catalog, psf
+from romanisim import image, parameters, catalog, psf, util
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 from astropy.time import Time
+from astropy import table
 import asdf
 import webbpsf
 from astropy.modeling.functional_models import Sersic2D
@@ -37,6 +38,30 @@ def test_in_bounds():
     yy = np.array([50, 51, -20, 1002, -50, 1051])
     assert ~np.any(image.in_bounds(xx, yy, bounds, 0))
     assert np.all(image.in_bounds(xx, yy, bounds, 60))
+
+
+def test_trim_objlist():
+    cen = SkyCoord(ra=0 * u.deg, dec=0 * u.deg)
+    cat1 = catalog.make_dummy_table_catalog(cen, radius=0.001, nobj=1000)
+    # sources within 0.1 deg
+    cen2 = SkyCoord(ra=180 * u.deg, dec=0 * u.deg)
+    cat2 = catalog.make_dummy_table_catalog(cen2, radius=0.001, nobj=1000)
+    cat3 = catalog.make_dummy_table_catalog(cen, radius=0.003, nobj=1000)
+    affine = galsim.AffineTransform(
+        0.1, 0, 0, 0.1, origin=galsim.PositionI(50, 50),
+        world_origin=galsim.PositionD(0, 0))
+    wcs = galsim.TanWCS(affine,
+                        util.celestialcoord(cen))
+    # image is ~50 pix = 5 arcsec ~ 0.0013 deg.
+    im = galsim.Image(100, 100, wcs=wcs)
+
+    outcat = image.trim_objlist(cat1, im)
+    assert len(outcat) == len(cat1)  # no objects trimmed
+    outcat = image.trim_objlist(cat2, im)
+    assert len(outcat) == 0  # all objects trimmed
+    outcat = image.trim_objlist(cat3, im)
+    assert (len(outcat) > 0) and (len(outcat) < len(cat3))
+    # some objects in, some objects out
 
 
 def test_make_l2():
@@ -93,11 +118,21 @@ def set_up_image_rendering_things():
         catalog.CatalogObject(
             None, galsim.Sersic(4, half_light_radius=1) * vega_sed, None)
     ]
+    tabcat = table.Table()
+    tabcat['ra'] = [270.0]
+    tabcat['dec'] = [66.0]
+    tabcat[filter_name] = counts
+    tabcat['type'] = 'PSF'
+    tabcat['n'] = -1
+    tabcat['half_light_radius'] = -1
+    tabcat['pa'] = -1
+    tabcat['ba'] = -1
     return dict(im=im, impsfgray=impsfgray,
                 impsfchromatic=impsfchromatic,
                 bandpass=bandpass, counts=counts, fluxdict=fluxdict,
                 graycatalog=graycatalog,
-                chromcatalog=chromcatalog, filter_name=filter_name)
+                chromcatalog=chromcatalog, filter_name=filter_name,
+                tabcatalog=tabcat)
 
 
 def central_stamp(im, sz):
@@ -362,6 +397,7 @@ def test_simulate(tmp_path):
     for o in graycat:
         o.sky_pos = coord
     l0 = image.simulate(meta, graycat, webbpsf=True, level=0, usecrds=False)
+    l0tab = image.simulate(meta, imdict['tabcatalog'], webbpsf=True, level=0, usecrds=False)
     l1 = image.simulate(meta, graycat, webbpsf=True, level=1, usecrds=False)
     l2 = image.simulate(meta, graycat, webbpsf=True, level=2, usecrds=False)
     l2c = image.simulate(meta, chromcat, webbpsf=False, level=2, usecrds=False)
@@ -369,6 +405,7 @@ def test_simulate(tmp_path):
     # I've already tested as many of the image generation things as I can
     # think of at earlier stages.
     assert isinstance(l0, galsim.Image)
+    assert isinstance(l0tab, galsim.Image)
     for ll in [l1, l2, l2c]:
         af = asdf.AsdfFile()
         af.tree = {'roman': ll[0]}

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -81,10 +81,9 @@ if __name__ == '__main__':
                     'covers a lot of area or you have thought carefully about '
                     'the relation between the boresight and the SCA locations.')
         cat = Table.read(args.catalog)
-    objlist = catalog.table_to_catalog(cat, [args.bandpass])
     rng = galsim.UniformDeviate(args.seed)
     im, simcatobj = image.simulate(
-        metadata, objlist, usecrds=args.usecrds,
+        metadata, cat, usecrds=args.usecrds,
         webbpsf=args.webbpsf, level=args.level,
         rng=rng)
 


### PR DESCRIPTION
- Add function trimming input catalogs to sources vaguely near the detector
- Allow sending either list[CatalogObject] or Table to simulate_counts / simulate_counts_generic
- Make code more efficient when sending large number of sources, most of which fall off the detector.
- Refactor IPC code to improve testing.
- Make default ra/dec specification specify the location of the center of the WFI array rather than the boresight.
  - Update WCS tests & documentation accordingly.
- Add SOC tests for requirements:
  - DMS220: Adding read noise.
  - DMS225: inject a source into a ramp.
  - DMS226: Convolving an image with an IPC kernel.
  - DMS227: Making an L1 output file with the right structure.