### PR TITLE
use OpenAstronomy workflows and move MacOS jobs to weekly schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           echo "galsim_url=https://github.com/GalSim-developers/GalSim/raw/releases/2.4/examples/data/" >> $GITHUB_OUTPUT
           echo "path=/tmp/data" >> $GITHUB_OUTPUT
       - run: |
+          mkdir ${{ steps.data.outputs.path }}
           wget ${{ steps.data.outputs.webbpsf_url }} -O ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz
           cd ${{ steps.data.outputs.path }}
           tar -xzvf minimal-webbpsf-data.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         WEBBPSF_PATH: ${{ needs.data.outputs.webbpsf_path }}
         GALSIM_CAT_PATH: ${{ needs.data.outputs.galsim_cat_path }}
       cache-path: ${{ needs.data.outputs.path }}
-      cache-key: ${{ needs.data.outputs.hash }}
+      cache-key: data-${{ needs.data.outputs.hash }}
       envs: |
         - linux: test-oldestdeps-cov-xdist
           python-version: 3.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     name: Download data
     runs-on: ubuntu-latest
     outputs:
-      path: ${{ steps.data_path.outputs.path }}
+      path: ${{ steps.data.outputs.path }}
       hash: ${{ steps.data_hash.outputs.hash }}
       webbpsf_path: ${{ steps.webbpsf_path.outputs.path }}
       galsim_cat_path: ${{ steps.galsim_cat_path.outputs.path }}
@@ -34,29 +34,31 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - id: data_path
-        run: echo "path=$HOME/work/romanisim/romanisim/romanisim/data" >> $GITHUB_OUTPUT
+      - id: data
+        run: |
+          echo "webbpsf_url=https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz" >> $GITHUB_OUTPUT
+          echo "galsim_url=https://github.com/GalSim-developers/GalSim/raw/releases/2.4/examples/data/" >> $GITHUB_OUTPUT
+          echo "path=$HOME/work/romanisim/romanisim/romanisim/data" >> $GITHUB_OUTPUT
       - run: |
-          wget https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz -O ${{ steps.data_path.outputs.path }}/minimal-webbpsf-data.tar.gz
-          cd ${{ steps.data_path.outputs.path }}
+          wget ${{ steps.data.outputs.webbpsf_url }} -O ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz
+          cd ${{ steps.data.outputs.path }}
           tar -xzvf minimal-webbpsf-data.tar.gz
           mkdir galsim-data
-          GALSIM_URL=https://github.com/GalSim-developers/GalSim/raw/releases/2.4/examples/data/
-          wget $GALSIM_URL/real_galaxy_catalog_23.5_example.fits -O galsim-data/real_galaxy_catalog_23.5_example.fits
-          wget $GALSIM_URL/real_galaxy_catalog_23.5_example_selection.fits -O galsim-data/real_galaxy_catalog_23.5_example_selection.fits
-          wget $GALSIM_URL/real_galaxy_catalog_23.5_example_fits.fits -O galsim-data/real_galaxy_catalog_23.5_example_fits.fits
+          wget ${{ steps.data.outputs.galsim_url }}/real_galaxy_catalog_23.5_example.fits -O galsim-data/real_galaxy_catalog_23.5_example.fits
+          wget ${{ steps.data.outputs.galsim_url }}/real_galaxy_catalog_23.5_example_selection.fits -O galsim-data/real_galaxy_catalog_23.5_example_selection.fits
+          wget ${{ steps.data.outputs.galsim_url }}/real_galaxy_catalog_23.5_example_fits.fits -O galsim-data/real_galaxy_catalog_23.5_example_fits.fits
       - id: data_hash
         run: echo "hash=${{ hashFiles( 'romanisim/data' ) }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
-          path: ${{ steps.data_path.outputs.path }}
+          path: ${{ steps.data.outputs.path }}
           key: data-${{ steps.data_hash.outputs.hash }}
       - id: webbpsf_path
-        run: echo "path=${{ steps.data_path.outputs.path }}/webbpsf-data" >> $GITHUB_OUTPUT
+        run: echo "path=${{ steps.data.outputs.path }}/webbpsf-data" >> $GITHUB_OUTPUT
       - id: galsim_cat_path
-        run: echo "path=${{ steps.data_path.outputs.path }}/galsim-data/real_galaxy_catalog_23.5_example.fits" >> $GITHUB_OUTPUT
+        run: echo "path=${{ steps.data.outputs.path }}/galsim-data/real_galaxy_catalog_23.5_example.fits" >> $GITHUB_OUTPUT
   test:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     needs: [ data ]
     with:
       setenv: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           echo "webbpsf_url=https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz" >> $GITHUB_OUTPUT
           echo "galsim_url=https://github.com/GalSim-developers/GalSim/raw/releases/2.4/examples/data/" >> $GITHUB_OUTPUT
-          echo "path=$HOME/work/romanisim/romanisim/romanisim/data" >> $GITHUB_OUTPUT
+          echo "path=/tmp/data" >> $GITHUB_OUTPUT
       - run: |
           wget ${{ steps.data.outputs.webbpsf_url }} -O ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz
           cd ${{ steps.data.outputs.path }}

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo "webbpsf_url=https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz" >> $GITHUB_OUTPUT
           echo "galsim_url=https://github.com/GalSim-developers/GalSim/raw/releases/2.4/examples/data/" >> $GITHUB_OUTPUT
-          echo "path=$HOME/work/romanisim/romanisim/romanisim/data" >> $GITHUB_OUTPUT
+          echo "path=/tmp/data" >> $GITHUB_OUTPUT
       - run: |
           wget ${{ steps.data.outputs.webbpsf_url }} -O ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz
           cd ${{ steps.data.outputs.path }}

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -25,6 +25,7 @@ jobs:
           echo "galsim_url=https://github.com/GalSim-developers/GalSim/raw/releases/2.4/examples/data/" >> $GITHUB_OUTPUT
           echo "path=/tmp/data" >> $GITHUB_OUTPUT
       - run: |
+          mkdir ${{ steps.data.outputs.path }}
           wget ${{ steps.data.outputs.webbpsf_url }} -O ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz
           cd ${{ steps.data.outputs.path }}
           tar -xzvf minimal-webbpsf-data.tar.gz

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -48,7 +48,7 @@ jobs:
         WEBBPSF_PATH: ${{ needs.data.outputs.webbpsf_path }}
         GALSIM_CAT_PATH: ${{ needs.data.outputs.galsim_cat_path }}
       cache-path: ${{ needs.data.outputs.path }}
-      cache-key: ${{ needs.data.outputs.hash }}
+      cache-key: data-${{ needs.data.outputs.hash }}
       envs: |
         - macos: test-xdist
           python-version: 3.8

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -11,7 +11,7 @@ jobs:
     name: Download data
     runs-on: ubuntu-latest
     outputs:
-      path: ${{ steps.data_path.outputs.path }}
+      path: ${{ steps.data.outputs.path }}
       hash: ${{ steps.data_hash.outputs.hash }}
       webbpsf_path: ${{ steps.webbpsf_path.outputs.path }}
       galsim_cat_path: ${{ steps.galsim_cat_path.outputs.path }}
@@ -19,29 +19,31 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - id: data_path
-        run: echo "path=$HOME/work/romanisim/romanisim/romanisim/data" >> $GITHUB_OUTPUT
+      - id: data
+        run: |
+          echo "webbpsf_url=https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz" >> $GITHUB_OUTPUT
+          echo "galsim_url=https://github.com/GalSim-developers/GalSim/raw/releases/2.4/examples/data/" >> $GITHUB_OUTPUT
+          echo "path=$HOME/work/romanisim/romanisim/romanisim/data" >> $GITHUB_OUTPUT
       - run: |
-          wget https://stsci.box.com/shared/static/n1fealx9q0m6sdnass6wnyfikvxtc0zz.gz -O ${{ steps.data_path.outputs.path }}/minimal-webbpsf-data.tar.gz
-          cd ${{ steps.data_path.outputs.path }}
+          wget ${{ steps.data.outputs.webbpsf_url }} -O ${{ steps.data.outputs.path }}/minimal-webbpsf-data.tar.gz
+          cd ${{ steps.data.outputs.path }}
           tar -xzvf minimal-webbpsf-data.tar.gz
           mkdir galsim-data
-          GALSIM_URL=https://github.com/GalSim-developers/GalSim/raw/releases/2.4/examples/data/
-          wget $GALSIM_URL/real_galaxy_catalog_23.5_example.fits -O galsim-data/real_galaxy_catalog_23.5_example.fits
-          wget $GALSIM_URL/real_galaxy_catalog_23.5_example_selection.fits -O galsim-data/real_galaxy_catalog_23.5_example_selection.fits
-          wget $GALSIM_URL/real_galaxy_catalog_23.5_example_fits.fits -O galsim-data/real_galaxy_catalog_23.5_example_fits.fits
+          wget ${{ steps.data.outputs.galsim_url }}/real_galaxy_catalog_23.5_example.fits -O galsim-data/real_galaxy_catalog_23.5_example.fits
+          wget ${{ steps.data.outputs.galsim_url }}/real_galaxy_catalog_23.5_example_selection.fits -O galsim-data/real_galaxy_catalog_23.5_example_selection.fits
+          wget ${{ steps.data.outputs.galsim_url }}/real_galaxy_catalog_23.5_example_fits.fits -O galsim-data/real_galaxy_catalog_23.5_example_fits.fits
       - id: data_hash
         run: echo "hash=${{ hashFiles( 'romanisim/data' ) }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
-          path: ${{ steps.data_path.outputs.path }}
+          path: ${{ steps.data.outputs.path }}
           key: data-${{ steps.data_hash.outputs.hash }}
       - id: webbpsf_path
-        run: echo "path=${{ steps.data_path.outputs.path }}/webbpsf-data" >> $GITHUB_OUTPUT
+        run: echo "path=${{ steps.data.outputs.path }}/webbpsf-data" >> $GITHUB_OUTPUT
       - id: galsim_cat_path
-        run: echo "path=${{ steps.data_path.outputs.path }}/galsim-data/real_galaxy_catalog_23.5_example.fits" >> $GITHUB_OUTPUT
+        run: echo "path=${{ steps.data.outputs.path }}/galsim-data/real_galaxy_catalog_23.5_example.fits" >> $GITHUB_OUTPUT
   test:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     needs: [ data ]
     with:
       setenv: |

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -1,27 +1,12 @@
-name: CI
+name: Weekly cron
 
 on:
-  push:
-    branches:
-      - main
-      - '*.x'
-    tags:
-      - '*'
-  pull_request:
-    branches:
-      - main
   schedule:
-    # Weekly Monday 9AM build
-    # * is a special character in YAML so you have to quote this string
-    - cron: '0 9 * * 0'
+    # Weekly Monday 6AM build
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
 
 jobs:
-  check:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
-    with:
-      envs: |
-        - linux: check-style
-        - linux: build-dist
   data:
     name: Download data
     runs-on: ubuntu-latest
@@ -65,18 +50,9 @@ jobs:
       cache-path: ${{ needs.data.outputs.path }}
       cache-key: ${{ needs.data.outputs.hash }}
       envs: |
-        - linux: test-oldestdeps-cov-xdist
-          python-version: 3.8
-        - linux: test-xdist
-          python-version: 3.8
-        - linux: test-xdist
-          python-version: 3.9
-        - linux: test-xdist
-          python-version: 3.10
-        - linux: test-xdist
-          python-version: 3.11
         - macos: test-xdist
-          python-version: 3.11
-        - linux: test-pyargs-xdist
-        - linux: test-xdist-cov
-          coverage: codecov
+          python-version: 3.8
+        - macos: test-xdist
+          python-version: 3.9
+        - macos: test-xdist
+          python-version: 3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
 ]
 dependencies = [
-    'asdf >=2.9.2',
+    'asdf >=2.14.2',
     'astropy >=5.0.4',
     'crds >=10.3.1',
     'defusedxml',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     'asdf >=2.14.2',
     'astropy >=5.0.4',
     'crds >=10.3.1',
-    'defusedxml',
+    'defusedxml >=0.5',
     'galsim >=2.3',
     'gwcs >=0.18.1',
     'jsonschema >=4.0.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     'asdf >=2.14.2',
-    'astropy >=5.0.4',
+    'astropy >=5.2',
     'crds >=10.3.1',
     'defusedxml >=0.5',
     'galsim >=2.3',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     'defusedxml',
     'galsim >=2.3',
     'gwcs >=0.18.1',
-    'jsonschema >=3.0.2',
+    'jsonschema >=4.0.1',
     'webbpsf >=1.0.0',
     'roman_datamodels >=0.14.1',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,3 +108,8 @@ report = { exclude_lines = [
     'raise NotImplementedError',
     'if __name__ == "__main__":',
 ] }
+
+[tool.ruff]
+extend-ignore = [
+    "E501", # Line too long
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     'crds >=10.3.1',
     'defusedxml',
     'galsim >=2.3',
-    'gwcs >=0.16.1',
+    'gwcs >=0.18.1',
     'jsonschema >=3.0.2',
     'webbpsf >=1.0.0',
     'roman_datamodels >=0.14.1',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,8 @@
 [tox]
-envlist =
+env_list =
     check-{style,security}
     test{,-pyargs,-regtests,-devdeps}{,-cov}-xdist
-    test-numpy{120,121,122}
-    build-{twine,docs}
-isolated_build = true
-usedevelop = true
+    build-{dist,docs}
 
 # tox environments are constructed with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
@@ -20,9 +17,9 @@ usedevelop = true
 description = check code style, e.g. with flake8
 skip_install = true
 deps =
-    flake8
+    ruff
 commands =
-    flake8 . {posargs}
+    ruff . {posargs}
 
 [testenv:check-security]
 description = run bandit to check security compliance
@@ -31,30 +28,17 @@ deps =
 commands =
     bandit romanisim -r -x tests,regtest
 
-[testenv:check-build]
-description = check build sdist/wheel and a strict twine check for metadata
-skip_install = true
-deps =
-    build
-    twine>=3.3
-commands =
-    python -m build .
-    twine check --strict dist/*
-
 [testenv]
 description =
     run tests
     devdeps: with the latest developer version of key dependencies
+    oldestdeps: with the oldest supported version of key dependencies
     pyargs: with --pyargs on installed package
     warnings: treating warnings as errors
     regtests: with --bigdata and --slow flags
     cov: with coverage
     xdist: using parallel processing
-# The following indicates which `optional-dependencies` from `pyproject.toml` will be installed
-extras =
-    test
-# Pass through the following environment variables which may be needed for the CI
-passenv =
+pass_env =
     HOME
     CI
     TOXENV
@@ -63,7 +47,16 @@ passenv =
     CODECOV_*
     WEBBPSF_PATH
     GALSIM_CAT_PATH
-usedevelop = true
+extras =
+    test
+deps =
+    xdist: pytest-xdist
+    devdeps: -rrequirements-dev.txt
+    oldestdeps: minimum_dependencies
+commands_pre =
+    oldestdeps: minimum_dependencies romanisim --filename requirements-min.txt
+    oldestdeps: pip install -r requirements-min.txt
+    pip freeze
 commands =
     pip freeze
     pytest \
@@ -72,22 +65,20 @@ commands =
     regtests: --bigdata --slow --basetemp={homedir}/test_outputs \
     xdist: -n auto \
     {posargs}
-deps =
-    xdist: pytest-xdist
-    devdeps: -rrequirements-dev.txt
-    numpy120: numpy==1.20.*
-    numpy121: numpy==1.21.*
-    numpy122: numpy==1.22.*
-commands_pre =
-    python -m pip install --upgrade pip
-# Don't treat positional arguments passed to tox as file system paths
-args_are_paths = false
 
 [testenv:pyargs]
 changedir = {homedir}
 usedevelop = false
 commands =
-    pyargs: pytest {toxinidir}/docs --pyargs {posargs:romanisim}
+    pyargs: pytest {project_root}/docs --pyargs {posargs:romanisim}
+    
+[testenv:build-dist]
+description = check build sdist/wheel
+skip_install = true
+deps =
+    build
+commands =
+    python -m build .
 
 [testenv:build-docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
This PR abstracts CI workflows to the OpenAstronomy workflows; this should reduce maintenance for updating and maintaining actions. Additionally, these changes move the majority of MacOS jobs to the weekly scheduled workflow. This should alleviate the issue where the limited MacOS runners for the organization are not available for CI jobs.

<img width="859" alt="image" src="https://user-images.githubusercontent.com/16024299/226998696-cf940f94-d529-410b-9d76-505c1298e58b.png">