### PR TITLE
Remove romancal dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     'galsim >=2.3',
     'rad >=0.14.1',
     'roman_datamodels >=0.14.1',
-    'romancal >=0.10',
     'gwcs >=0.18.1',
     'jsonschema >=4.0.1',
     'webbpsf >=1.0.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ test = [
     'pytest-openfiles >=0.5.0',
     'pytest-doctestplus >=0.10.0',
     'pytest-cov >=2.9.0',
-    'codecov >=1.6.0',
     'flake8 >=3.6.0',
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 git+https://github.com/asdf-format/asdf
 git+https://github.com/spacetelescope/roman_datamodels
 git+https://github.com/spacetelescope/rad
-git+https://github.com/spacetelescope/romancal
 astropy>=0.0.dev0

--- a/romanisim/tests/test_cr.py
+++ b/romanisim/tests/test_cr.py
@@ -12,10 +12,10 @@ def test_traverse():
     i2, j2 = np.random.random((2, 100)) * 100
     for i in range(len(i1)):
         ii, jj, lengths = cr.traverse((i1[i], j1[i]), (i2[i], j2[i]), 100, 100)
+        totlen = np.hypot(i1[i] - i2[i], j1[i] - j2[i])
         assert len(set(zip(ii, jj))) == len(ii)
         assert np.all(lengths > 0)
-        assert np.all(lengths < np.hypot(i1[i] - i2[i], j1[i] - j2[i]))
-
+        assert np.all((lengths < totlen) | np.isclose(lengths, totlen))
 
 def test_create_sampler():
     xx = np.linspace(0, 1, 1000)

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -20,7 +20,7 @@ import warnings
 import numpy as np
 import astropy.coordinates
 from astropy import units as u
-from astropy.modeling.models import RotationSequence3D, Scale
+from astropy.modeling import models
 import astropy.time
 import roman_datamodels
 import crds
@@ -204,12 +204,12 @@ def make_wcs(targ_pos, distortion, roll_ref=0, v2_ref=0, v3_ref=0,
     # angles = np.array([v2_ref, -v3_ref, roll_ref, dec_ref, -ra_ref])
     # axes = "zyxyz"
     # rot = RotationSequence3D(angles, axes_order=axes)
-    rot = RotationSequence3D(
+    rot = models.RotationSequence3D(
         [v2_ref, -v3_ref, roll_ref, dec_ref, -ra_ref], 'zyxyz')
 
     # distortion takes pixels to V2V3
     # V2V3 are in arcseconds, while SphericalToCartesian expects degrees.
-    model = (distortion | (Scale(1 / 3600) & Scale(1 / 3600))
+    model = (distortion | (models.Scale(1 / 3600) & models.Scale(1 / 3600))
              | gwcs.geometry.SphericalToCartesian(wrap_lon_at=wrap_v2_at)
              | rot
              | gwcs.geometry.CartesianToSpherical(wrap_lon_at=wrap_lon_at))

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -22,7 +22,8 @@ import astropy.coordinates
 from astropy import units as u
 from astropy.modeling.models import RotationSequence3D, Scale
 import astropy.time
-
+import roman_datamodels
+import crds
 import gwcs.geometry
 from gwcs import coordinate_frames as cf
 import gwcs.wcs
@@ -30,9 +31,6 @@ import galsim.wcs
 from galsim import roman
 from . import util
 
-from stpipe import crds_client
-
-import roman_datamodels
 
 # Needed until RCAL release unfreezing link to RDM/RAD versions 0.14.1
 try:
@@ -133,11 +131,11 @@ def get_wcs(image, usecrds=True, distortion=None):
         image_mod.meta.wcsinfo.dec_ref * u.deg)
 
     if (distortion is None) and usecrds:
-        dist_name = crds_client.get_reference_file(
+        dist_name = crds.getreferences(
             image_mod.get_crds_parameters(),
-            'distortion',
-            'roman',
-        )
+            reftypes=['distortion'],
+            observatory='roman',
+        )['distortion']
 
         dist_model = roman_datamodels.datamodels.DistortionRefModel(dist_name)
         distortion = dist_model.coordinate_distortion_transform


### PR DESCRIPTION
This removes the simulator's dependency on romancal, which should not be needed and is causing test failures.