### PR TITLE
remove usages of deprecated `codecov` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ test = [
     'pytest-openfiles >=0.5.0',
     'pytest-doctestplus >=0.10.0',
     'pytest-cov >=2.9.0',
-    'codecov >=1.6.0',
     'flake8 >=3.6.0',
 ]
 


### PR DESCRIPTION
the `codecov` package is now deprecated and has been yanked from PyPI