### PR TITLE
Propagate DQ information from image simulation to ramp fitting.

### DIFF
--- a/docs/romanisim/install.rst
+++ b/docs/romanisim/install.rst
@@ -32,3 +32,30 @@ Using CRDS requires specifying the ``CRDS_PATH`` and
 ``CRDS_SERVER_URL`` variables.  CRDS is not used unless the
 ``--usecrds`` argument is specified; do not include this argument
 unless you have access to the Roman CRDS.
+
+That said, the basic install process looks like this::
+
+    pip install romanisim
+    # to get a specific version, use instead
+    # pip install romanisim==0.1
+    # to be able to run the tests for a specific version, use instead
+    # pip install romanisim[test]==0.1
+
+    # get webbpsf data and untar it
+    mkdir -p $HOME/data/webbpsf-data
+    cd $HOME/data/webbpsf-data
+    wget https://stsci.box.com/shared/static/t90gqazqs82d8nh25249oq1obbjfstq8.gz -O webbpsf-data.tar.gz
+    tar -xzf webbpsf-data.tar.gz
+    export WEBBPSF_PATH=$PWD/webbpsf-data
+
+    # get galsim galaxy catalogs
+    # Note: ~5 GB each, takes a little while to download.
+    # Both are needed for tests.  Neither are needed if you are
+    # exclusively using analytic model galaxies.
+    galsim_download_cosmos -s 23.5
+    galsim_download_cosmos -s 25.2
+
+You may wish to, for example, set up a new python virtual environment
+before running the above, or choose a different directory for
+WebbPSF's data files.
+

--- a/docs/romanisim/l2.rst
+++ b/docs/romanisim/l2.rst
@@ -11,8 +11,10 @@ This approach does not handle cosmic rays or saturated pixels well, though for m
 
 The second approach follows `Casertano+2022 <https://webbpsf.readthedocs.io/en/latest/installation.html#installing-the-required-data-files>`_.  In this approach, a diagonal set of weights is used in place of the full covariance matrix.  The choice of weights depend on the particular pattern of reads assigned to each resultant and the amount of flux in the ramp, allowing them to interpolate from simply differencing the first and last resultants when the flux is very large to weighting the resultants by the number of reads when the flux is zero.  This approach more efficiently handles dealing with ramps that have been split by cosmic rays, and obtaining uncertainties within a few percent of the "optimal" weighting approach.  For these cases, we report final ramp slopes and variances derived from the inverse variance weighted subramp slopes and variances, using the read-noise derived variances.
 
-This is a fairly faithful representation of how level two image construction works, so there are not many additional effects to add here.
+This is a fairly faithful representation of how level two image construction works, so there are not many additional effects to add here.  But mentioning some limitations:
 
-* We are ignoring saturation both here and at the L1 stage.
+* We have a simplistic saturation treatment, just clipping resultants that exceed
+  the saturation level to the saturation level and throwing a flag.
+* We do not include dark counts as part of the Poisson noise term in the ramp fitting.
 
 .. automodapi:: romanisim.ramp

--- a/docs/romanisim/overview.rst
+++ b/docs/romanisim/overview.rst
@@ -4,8 +4,8 @@ Overview
 romanisim simulates Roman Wide-Field Imager images of astronomical scenes
 described by catalogs of sources.  The simulation includes:
 
-* convolution of the sources by the appropriate PSF for each detector
-* realistic world coordinate system
+* convolution of the sources by the Roman point spread function
+* optical distortion
 * sky background
 * level 1 image support (3D image stack of up-the-ramp samples)
 * level 2 image support (2D image after calibration & ramp fitting)
@@ -15,15 +15,26 @@ described by catalogs of sources.  The simulation includes:
 * read noise
 * inter-pixel capacitance
 * non-linearity
-* reciprocity failure
+* saturation
+* ramp fitting
+* source injection
 
 The simulator is based on galsim and most of these features directly invoke the
 equivalents in the galsim.roman package.  The chief additions of this package
-on top of the galsim.roman implementation are using "official" PSF, WCS, and
-reference files from the Roman CRDS (not yet public!) and webbpsf.  This
+on top of the galsim.roman implementation are using "official" webbpsf
+PSF, and distortion and reference files from the Roman CRDS (not yet
+public!).  This
 package also implements WFI up-the-ramp sampled and averaged images like those
 that will be downlinked from the telescope, and the official Roman WFI file
 format (asdf).
+
+Future expected features include:
+
+* frame zero effects
+* L3 image simulations
+* "image-based" simulation inputs (i.e., provide an input image based
+  on a galaxy hydro sim; romanisim applies the Roman PSF &
+  instrumental effects on top to produce a detailed instrumental simulation)
 
 The best way to interact with romanisim is to make an image.  Running ::
 

--- a/docs/romanisim/util.rst
+++ b/docs/romanisim/util.rst
@@ -6,7 +6,6 @@ The simulator utility module consists of miscellaneous utility routines intended
 * turning astropy coordinates into galsim coordinates and vice-versa
 * making an RGB image from image slices
 * generating points at random in a region on the sky
-* flattening & unflattening nested dictionaries.
 
 .. automodapi:: romanisim.util
 

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -114,13 +114,17 @@ def make_l2(resultants, ma_table, read_noise=None, gain=None, flat=None,
 
     from . import ramp
     log.info('Fitting ramps.')
+
+    # commented out code below is inverse-covariance ramp fitting
+    # which doesn't presently support DQ information
     # rampfitter = ramp.RampFitInterpolator(ma_table)
     # ramppar, rampvar = rampfitter.fit_ramps(resultants * gain,
     #                                         read_noise * gain)
+
     if dq is None:
         dq = np.zeros(resultants.shape, dtype='i4')
     ramppar, rampvar = ramp.fit_ramps_casertano(resultants * gain, dq,
-                                                read_noise, ma_table)
+                                                read_noise * gain, ma_table)
 
     log.warning('The ramp fitter is unaware of noise from dark current because '
                 'it runs on dark-subtracted images.  We could consider adding '

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -525,7 +525,7 @@ def make_l1(counts, ma_table_number,
 
     Returns
     -------
-    l1, l1dq
+    l1, dq
     l1: np.ndarray[n_resultant, nx, ny]
         resultants image array including systematic effects
     dq: np.ndarray[n_resultant, nx, ny]

--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -27,9 +27,8 @@ default_parameters_dictionary = {
 }
 
 
+# default read noise
 read_noise = 5.0 * ru.DN
-# grabbing the median of the read noise image from CRDS at
-# some point
 
 gain = 1 * ru.electron / ru.DN
 
@@ -50,6 +49,7 @@ ipc_kernel = np.array(
      [0.21, 1.62, 0.2]])
 ipc_kernel /= np.sum(ipc_kernel)
 
+# V2/V3 coordinates of "center" of WFI array (convention)
 v2v3_wficen = (1546.3846181707652, -892.7916365721071)
 
 # persistence parameter dictionary
@@ -57,5 +57,11 @@ v2v3_wficen = (1546.3846181707652, -892.7916365721071)
 # e.g., MA table 1 has ~144 s, so this is ~1 electron over the whole exposure.
 persistence = dict(A=0.017, x0=6.0e4, dx=5.0e4, alpha=0.045, gamma=1,
                    half_well=50000, ignorerate=0.01)
+
+# default saturation level in DN absent reference file information
+saturation = 55000 * ru.DN
+
+# arbitrary constant to add to initial L1 image so that pixels aren't clipped at zero.
+pedestal = 100 * ru.DN
 
 dqbits = dict(saturated=2, jump_det=4)

--- a/romanisim/ramp_fit_casertano.pyx
+++ b/romanisim/ramp_fit_casertano.pyx
@@ -5,6 +5,7 @@ import romanisim.ramp
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
+@cython.cdivision(True)
 def fit_ramps(np.ndarray[float, ndim=2] resultants,
               np.ndarray[int, ndim=2] dq,
               np.ndarray[float, ndim=1] read_noise, ma_table):
@@ -65,7 +66,7 @@ def fit_ramps(np.ndarray[float, ndim=2] resultants,
     cdef np.ndarray[int] resstart = np.zeros(nramp, dtype='i4') - 1
     cdef np.ndarray[int] resend = np.zeros(nramp, dtype='i4') - 1
     cdef np.ndarray[int] pix = np.zeros(nramp, dtype='i4') - 1
-    cdef int i, j
+    cdef int i, j, m
     cdef int inramp = -1
     cdef int rampnum = 0
     for i in range(npixel):

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -75,9 +75,10 @@ def test_make_l2():
     assert np.allclose(slopes, 0)
     resultants[:, :, :] = np.arange(4)[:, None, None]
     resultants *= ru.DN
+    gain = 1 * ru.electron / ru.DN
     slopes, readvar, poissonvar = image.make_l2(
         resultants, ma_table,
-        gain=1 * ru.electron / ru.DN, flat=1, dark=0)
+        gain=gain, flat=1, dark=0)
     assert np.allclose(slopes, 1 / parameters.read_time / 4 * u.electron / u.s)
     assert np.all(np.array(slopes.shape) == np.array(readvar.shape))
     assert np.all(np.array(slopes.shape) == np.array(poissonvar.shape))
@@ -98,7 +99,7 @@ def test_make_l2():
     assert np.allclose(readvar2, readvar1 / 0.5**2)
     assert np.allclose(poissonvar2, poissonvar1 / 0.5**2)
     slopes, readvar, poissonvar = image.make_l2(
-        resultants, ma_table, read_noise=1, gain=1, flat=1,
+        resultants, ma_table, read_noise=1, gain=gain, flat=1,
         dark=resultants)
     assert np.allclose(slopes, 0)
 
@@ -445,7 +446,7 @@ def test_simulate(tmp_path):
     log.info('DMS221: Successfully added cosmic rays to an L1 image.')
     l2 = image.simulate(meta, graycat, webbpsf=True, level=2,
                         usecrds=False, crparam=dict())
-    # through in some CRs for fun
+    # throw in some CRs for fun
     l2c = image.simulate(meta, chromcat, webbpsf=False, level=2,
                          usecrds=False)
     persist = persistence.Persistence()


### PR DESCRIPTION
* Propagate DQ information from image simulation to ramp fitting so that we can properly treat saturated sources and cosmic rays when fitting ramps.
* Update docs.
* Add pedestal to L1 image so that noise doesn't lead to clipping at zero.
* Update tests to accommodate new L1 pedestal---don't assume that there is no pedestal.
* Update cython ramp fitting to mark more things as C variables; ~100x speedup (oops).