### PR TITLE
test against pre-built binaries of `numpy`

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -59,3 +59,4 @@ jobs:
           python-version: 3.9
         - macos: test-xdist
           python-version: 3.10
+        - linux: test-devdeps-xdist

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ git+https://github.com/asdf-format/asdf
 git+https://github.com/spacetelescope/roman_datamodels
 git+https://github.com/spacetelescope/rad
 astropy>=0.0.dev0
+numpy>=0.0.dev0


### PR DESCRIPTION
Resolves [SCSB-69](https://jira.stsci.edu/browse/SCSB-69)

run `devdeps` tests against both `astropy` and `numpy` pre-built `pre` wheels