### PR TITLE
fix readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,9 +16,15 @@ formats:
   - htmlzip
   - pdf
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  system_packages: false
   install:
     - method: pip
       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,8 +19,10 @@ formats:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: mambaforge-4.10
 
+conda:
+  environment: docs/rtd_environment.yaml
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,0 +1,8 @@
+name: rtd311
+channels:
+ - conda-forge
+ - defaults
+dependencies:
+ - python=3.11
+ - pip
+ - graphviz


### PR DESCRIPTION
attempts to fix RTD build by using the new `build` block (`python.version` is deprecated) and also building the environment with `mamba` to avoid issues with availability of `openssl` and `graphviz`