### PR TITLE
revert astropy prerelease wheel spec and use nightly Scipy wheel index

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 git+https://github.com/asdf-format/asdf
 git+https://github.com/spacetelescope/roman_datamodels
 git+https://github.com/spacetelescope/rad
-astropy>=0.0.dev0
+git+https://github.com/astropy/astropy
 numpy>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -48,15 +48,17 @@ pass_env =
     CODECOV_*
     WEBBPSF_PATH
     GALSIM_CAT_PATH
+set_env =
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 extras =
     test
 deps =
     xdist: pytest-xdist
-    devdeps: -rrequirements-dev.txt
     oldestdeps: minimum_dependencies
 commands_pre =
     oldestdeps: minimum_dependencies romanisim --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt
+    devdeps: pip install -r requirements-dev.txt -U --upgrade-strategy eager
     pip freeze
 commands =
     pip freeze


### PR DESCRIPTION
This PR addresses @WilliamJamieson's comments in https://github.com/spacetelescope/romancal/pull/695#discussion_r1189078751; the change to the Astropy dev spec in #50 didn't actually accomplish anything, and `numpy` and `scipy` wheels are hosted at a different index URL