### PR TITLE
Update tests to be less noisy

### DIFF
--- a/romanisim/ramp.py
+++ b/romanisim/ramp.py
@@ -525,8 +525,9 @@ def fit_ramps_casertano(resultants, dq, read_noise, ma_table):
     npix = resultants.reshape(resultants.shape[0], -1).shape[1]
     # we need to do some averaging to merge the results in each ramp.
     # inverse variance weights based on slopereadvar
-    weight = ((rampfitdict['slopereadvar'] != 0) / (
+    weight = ((rampfitdict['slopepoissonvar'] != 0) / (
         rampfitdict['slopereadvar'] + (rampfitdict['slopereadvar'] == 0)))
+    weight = np.clip(weight, 0, 10**10)  # gracefully? handle read noise = 0 case.
     totweight = np.bincount(rampfitdict['pix'], weights=weight, minlength=npix)
     totval = np.bincount(rampfitdict['pix'],
                          weights=weight * rampfitdict['slope'],

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -79,7 +79,7 @@ def test_apportion_counts_to_resultants():
             sdev = np.std(res3[plane_index] - resultants[plane_index])
             assert (np.abs(sdev - read_noise / np.sqrt(len(restij)))
                     < 20 * sdev / np.sqrt(2 * len(counts.ravel())))
-        log.info('DMS220: successfully added read noise to resultants.')
+    log.info('DMS220: successfully added read noise to resultants.')
 
 
 @pytest.mark.soctests


### PR DESCRIPTION
Update the tests to only print about passing each test once.  Also fix a bug where the case where the read noise is exactly zero triggers bad behavior in ramp fitting.