### PR TITLE
Improve content of romanisim output files

### DIFF
--- a/romanisim/__init__.py
+++ b/romanisim/__init__.py
@@ -15,8 +15,11 @@ from pkg_resources import get_distribution, DistributionNotFound
 import logging
 
 log = logging.getLogger(__name__)
-logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+# I think we do want to change the format here, but stpipe is messing
+# with the logging somehow and the below leads to log messages being
+# printed three times.
+# logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s',
+#                     datefmt='%Y-%m-%d %H:%M:%S')
 log.setLevel(logging.INFO)
 
 try:

--- a/romanisim/bandpass.py
+++ b/romanisim/bandpass.py
@@ -26,6 +26,9 @@ from astropy import units as u
 galsim_bandpasses = ['Z087', 'Y106', 'J129', 'H158', 'F184', 'W149']
 galsim2roman_bandpass = {x: 'F' + x[1:] for x in galsim_bandpasses}
 roman2galsim_bandpass = {v: k for k, v in galsim2roman_bandpass.items()}
+# we should add some support for F213 (K) and F062.  That would require getting
+# zodiacal light estimates and maybe making a bandpass.
+# W149 is probably the same as F146 but we should compare.
 
 # provide some no-ops if we are given a key in the right bandpass
 galsim2roman_bandpass.update(**{k: k for k in roman2galsim_bandpass})

--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -11,6 +11,7 @@ from astropy import coordinates
 from astropy import table
 from astropy import units as u
 from . import util
+import romanisim.bandpass
 
 
 @dataclasses.dataclass
@@ -168,6 +169,8 @@ def make_galaxies(coord, n, radius=0.1, index=None, faintmag=26,
     """
     if bandpasses is None:
         bandpasses = roman.getBandpasses().keys()
+        bandpasses = [romanisim.bandpass.galsim2roman_bandpass[b]
+                      for b in bandpasses]
     locs = util.random_points_in_cap(coord, radius, n, rng=rng)
     if index is None:
         index = 3 / 5
@@ -245,6 +248,8 @@ def make_stars(coord, n, radius=0.1, index=None, faintmag=26,
     """
     if bandpasses is None:
         bandpasses = roman.getBandpasses().keys()
+        bandpasses = [romanisim.bandpass.galsim2roman_bandpass[b]
+                      for b in bandpasses]
     if truncation_radius is None:
         locs = util.random_points_in_cap(coord, radius, n, rng=rng)
     else:

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -26,7 +26,6 @@ import romanisim.bandpass
 import romanisim.psf
 import romanisim.persistence
 from romanisim import log
-import crds
 
 import roman_datamodels
 try:
@@ -626,6 +625,7 @@ def simulate(metadata, objlist,
     # line.
     if usecrds:
         refnames_lst = ['readnoise', 'dark', 'gain', 'linearity', 'saturation']
+        import crds
         reffiles = crds.getreferences(
             image_mod.get_crds_parameters(), reftypes=refnames_lst,
             observatory='roman')
@@ -710,7 +710,7 @@ def simulate(metadata, objlist,
         l2dq = np.bitwise_or.reduce(l1dq, axis=0)
         im, extras = make_asdf(
             *slopeinfo, metadata=image_mod.meta, persistence=persistence,
-            dq=l2dq)
+            dq=l2dq, imwcs=counts.wcs)
     else:
         extras = dict()
     extras['simcatobj'] = simcatobj
@@ -744,7 +744,7 @@ def make_test_catalog_and_images(
 
 
 def make_asdf(slope, slopevar_rn, slopevar_poisson, metadata=None,
-              filepath=None, persistence=None, dq=None):
+              filepath=None, persistence=None, dq=None, imwcs=None):
     """Wrap a galsim simulated image with ASDF/roman_datamodel metadata.
 
     Eventually this needs to get enough info to reconstruct a refit WCS.
@@ -800,6 +800,14 @@ def make_asdf(slope, slopevar_rn, slopevar_poisson, metadata=None,
     # var_flat: currently zero
     if metadata is not None:
         out['meta'].update(metadata)
+
+    if imwcs is not None:  # add a WCS
+        if isinstance(imwcs, wcs.GWCS):
+            out['meta'].update(wcs=imwcs.wcs)
+        else:
+            # make a gwcs WCS from a galsim.roman WCS
+            out['meta'].update(
+                wcs=wcs.wcs_from_fits_header(imwcs.header.header))
 
     out['data'] = slope
     out['dq'] = np.zeros(slope.shape, dtype='u4')

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -407,6 +407,9 @@ def make_asdf(resultants, dq=None, filepath=None, metadata=None, persistence=Non
     -------
     roman_datamodels.datamodels.ScienceRawModel
         L1 image
+    extras : dict
+        dictionary of additionally tabulated quantities, potentially
+        including DQ images and persistence information.
     """
 
     try:
@@ -419,17 +422,18 @@ def make_asdf(resultants, dq=None, filepath=None, metadata=None, persistence=Non
         shape=(len(resultants), npix, npix))
     if metadata is not None:
         out['meta'].update(metadata)
+    extras = dict()
     out['data'][:, nborder:-nborder, nborder:-nborder] = resultants
     if dq is not None:
-        out['dq'] = np.zeros(out['data'].shape, dtype='i4')
-        out['dq'][:, nborder:-nborder, nborder:-nborder] = dq
+        extras['dq'] = np.zeros(out['data'].shape, dtype='i4')
+        extras['dq'][:, nborder:-nborder, nborder:-nborder] = dq
     if persistence is not None:
-        out['meta']['persistence'] = persistence.to_dict()
+        extras['persistence'] = persistence.to_dict()
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': out}
+        af.tree = {'roman': out, 'romanisim': extras}
         af.write_to(filepath)
-    return out
+    return out, extras
 
 
 def ma_table_to_tij(ma_table_number):

--- a/romanisim/persistence.py
+++ b/romanisim/persistence.py
@@ -182,7 +182,7 @@ class Persistence:
         Persistence object stored in filename.
         """
         af = asdf.open(filename)
-        persistdict = af['roman']['meta']['persistence']
+        persistdict = af['romanisim']['persistence']
         return Persistence.from_dict(persistdict)
 
     def write(self, filename):
@@ -194,7 +194,7 @@ class Persistence:
             The file name to read
         """
         af = asdf.AsdfFile()
-        af.tree = dict(roman=dict(meta=dict(persistence=self.to_dict())))
+        af.tree = dict(romanisim=dict(persistence=self.to_dict()))
         af.write_to(filename)
 
 

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -485,13 +485,15 @@ def test_simulate(tmp_path):
         af = asdf.AsdfFile()
         af.tree = {'roman': ll[0]}
         af.validate()
-    l2, cat = l2
-    res = image.make_asdf(l2['data'], l2['var_rnoise'], l2['var_poisson'],
-                          filepath=tmp_path / 'l2.asdf')
-    af.tree = {'roman': res}
+    l2, extras = l2
+    af.tree = {'roman': l2}
     # DMS216
     af.validate()
     log.info('DMS216: successfully made a L2 file.')
+
+    imwcs = l2['meta'].get('wcs', None)
+    assert imwcs is not None
+    # nice if L2 images include the WCS.
 
 
 def test_make_test_catalog_and_images():

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -161,7 +161,8 @@ def test_make_l1_and_asdf(tmp_path):
         # than the number of counts
         assert np.all(resultants >= 0 * u.DN)
         assert np.all(np.diff(resultants, axis=0) >= 0 * u.DN)
-        res_forasdf = l1.make_asdf(resultants, filepath=tmp_path / 'tmp.asdf')
+        res_forasdf, extras = l1.make_asdf(
+            resultants, filepath=tmp_path / 'tmp.asdf')
         af = asdf.AsdfFile()
         af.tree = {'roman': res_forasdf}
         af.validate()

--- a/romanisim/tests/test_wcs.py
+++ b/romanisim/tests/test_wcs.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     import roman_datamodels.testing.utils as maker_utils
 
+
 def make_fake_distortion_function():
     """A very simple distortion function.
 
@@ -98,6 +99,21 @@ def test_wcs():
     # should be close to the reference v2 & v3 offset.
     assert np.abs(cc3.separation(cc4).to(u.arcsec).value
                   - np.hypot(*parameters.v2v3_wficen)) < 1
+
+
+def test_wcs_from_fits_header():
+    wcs1 = wcs.get_wcs(parameters.default_parameters_dictionary,
+                       usecrds=False)
+    wcs2 = wcs.wcs_from_fits_header(wcs1.header.header)
+    xg, yg = np.meshgrid(np.linspace(0, 4088, 100), np.linspace(0, 4088, 100))
+    rd1 = np.degrees(wcs1._radec(xg.copy(), yg.copy()))
+    rd2 = wcs2.pixel_to_world(xg.copy(), yg.copy())
+    rd1 = SkyCoord(ra=rd1[0] * u.deg, dec=rd1[1] * u.deg, frame=rd2.frame)
+    sep = rd1.separation(rd2).to(u.arcsec).value
+
+    # really end up with 10^-10 arcsec in my tests, but let's say that 10^-5
+    # is fine.
+    assert np.max(sep) < 1e-5
 
 
 @pytest.mark.skipif(

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -92,13 +92,13 @@ if __name__ == '__main__':
         persist = persistence.Persistence()
 
     rng = galsim.UniformDeviate(args.seed)
-    im, simcatobj = image.simulate(
+    im, extras = image.simulate(
         metadata, cat, usecrds=args.usecrds,
         webbpsf=args.webbpsf, level=args.level, persistence=persist,
         rng=rng)
 
     romanisimdict = vars(args)
-    romanisimdict['simcatobj'] = simcatobj
+    romanisimdict.update(**extras)
 
     af = asdf.AsdfFile()
     af.tree = {'roman': im, 'romanisim': romanisimdict}


### PR DESCRIPTION
* Move romanisim dq & persistence structures outside of the 'roman' asdf keyword, since romancal assumes it will understand everything under that keyword.
* Add the WCS to romanisim L2 output.
* Remove custom logging formatting to avoid stpipe interaction issue.
* Move crds module imports out of module level.