### PR TITLE
Use seeds more consistently in random number generation.

### DIFF
--- a/romanisim/__init__.py
+++ b/romanisim/__init__.py
@@ -15,11 +15,8 @@ from pkg_resources import get_distribution, DistributionNotFound
 import logging
 
 log = logging.getLogger(__name__)
-# I think we do want to change the format here, but stpipe is messing
-# with the logging somehow and the below leads to log messages being
-# printed three times.
-# logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s',
-#                     datefmt='%Y-%m-%d %H:%M:%S')
+logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S')
 log.setLevel(logging.INFO)
 
 try:

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -74,12 +74,13 @@ if __name__ == '__main__':
     metadata['instrument']['optical_element'] = args.bandpass
     metadata['exposure']['ma_table_number'] = args.ma_table_number
 
+    rng = galsim.UniformDeviate(args.seed)
     if args.catalog is None:
         twcs = wcs.get_wcs(metadata, usecrds=args.usecrds)
         rd_sca = twcs.toWorld(galsim.PositionD(
             galsim.roman.n_pix / 2, galsim.roman.n_pix / 2))
         cat = catalog.make_dummy_table_catalog(
-            rd_sca, bandpasses=[args.bandpass], nobj=args.nobj)
+            rd_sca, bandpasses=[args.bandpass], nobj=args.nobj, rng=rng)
     else:
         log.warning('Catalog input will probably not work unless the catalog '
                     'covers a lot of area or you have thought carefully about '
@@ -91,7 +92,6 @@ if __name__ == '__main__':
     else:
         persist = persistence.Persistence()
 
-    rng = galsim.UniformDeviate(args.seed)
     im, extras = image.simulate(
         metadata, cat, usecrds=args.usecrds,
         webbpsf=args.webbpsf, level=args.level, persistence=persist,


### PR DESCRIPTION
This PR swaps a few cases where random number generators were being used without seeds to use input seeds instead.It also continues to play around a bit with the logging.