### PR TITLE
Ensure no jitter is simulated by WebbPSF

### DIFF
--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -77,6 +77,9 @@ def make_psf(sca, filter_name, wcs=None, webbpsf=True, pix=None,
     wfi.filter = filter_name
     wfi.detector_position = pix
     oversample = kw.get('oversample', 4)
+    wfi.options['jitter'] = None
+    wfi.options['jitter_sigma'] = 0
+
     # webbpsf doesn't do distortion
     psf = wfi.calc_psf(oversample=oversample)
     gimg = galsim.Image(

--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -27,7 +27,7 @@ from romanisim import log
 
 
 def make_psf(sca, filter_name, wcs=None, webbpsf=True, pix=None,
-             chromatic=False, **kw):
+             chromatic=False, jitter_model='gaussian', jitter_sigma=0.012, **kw):
     """Make a PSF profile for Roman.
 
     Can construct both PSFs using galsim's built-in galsim.roman.roman_psfs
@@ -44,6 +44,11 @@ def make_psf(sca, filter_name, wcs=None, webbpsf=True, pix=None,
         scale of image for webbpsf PSFs
     pix : tuple (float, float)
         pixel location of PSF on focal plane
+    jitter_model : str
+        telescope pointing jitter model used by WebbPSF. Default is "gaussian"
+    jitter_sigma : float
+        standard deviation of the telescope pointing jitter [arcsec].
+        Default is 0.012 arcsec.
     **kw : dict
         Additional keywords passed to galsim.roman.getPSF
 
@@ -77,8 +82,8 @@ def make_psf(sca, filter_name, wcs=None, webbpsf=True, pix=None,
     wfi.filter = filter_name
     wfi.detector_position = pix
     oversample = kw.get('oversample', 4)
-    wfi.options['jitter'] = None
-    wfi.options['jitter_sigma'] = 0
+    wfi.options['jitter'] = jitter_model
+    wfi.options['jitter_sigma'] = jitter_sigma
 
     # webbpsf doesn't do distortion
     psf = wfi.calc_psf(oversample=oversample)


### PR DESCRIPTION
WebbPSF simulates telescope jitter by default ([see docs](https://webbpsf.readthedocs.io/en/latest/usage.html#simulating-telescope-jitter)):
```python
>>> import webbpsf
>>> wfi = webbpsf.WFI()
>>> wfi.options
{'jitter': 'gaussian', 'jitter_sigma': 0.012}
```
...which may or may not be what `romanisim` users want. This PR ensures there's no jitter simulated by default. Alternatively, we could add these as kwargs for `make_psf` instead.