### PR TITLE
Misc deprecation fixes and test failures.

### DIFF
--- a/romanisim/__init__.py
+++ b/romanisim/__init__.py
@@ -15,8 +15,8 @@ from pkg_resources import get_distribution, DistributionNotFound
 import logging
 
 log = logging.getLogger(__name__)
-logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+# logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s',
+#                     datefmt='%Y-%m-%d %H:%M:%S')
 log.setLevel(logging.INFO)
 
 try:

--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -210,14 +210,14 @@ def make_galaxies(coord, n, radius=0.1, index=None, faintmag=26,
     out['dec'] = locs.dec.to(u.deg).value
     out['type'] = types
     out['n'] = sersic_index
-    out['half_light_radius'] = hlr
-    out['pa'] = pa
-    out['ba'] = ba
+    out['half_light_radius'] = hlr.astype('f4')
+    out['pa'] = pa.astype('f4')
+    out['ba'] = ba.astype('f4')
     for bandpass in bandpasses:
         mag_thisband = mag + rng_numpy.normal(size=n)
         # sigma of one mag isn't nuts.  But this will be totally uncorrelated
         # in different bands, so we'll get some weird colored objects
-        out[bandpass] = 10.**(-mag_thisband / 2.5)
+        out[bandpass] = (10.**(-mag_thisband / 2.5)).astype('f4')
     return out
 
 
@@ -291,15 +291,15 @@ def make_stars(coord, n, radius=0.1, index=None, faintmag=26,
     out['ra'] = locs.ra.to(u.deg).value
     out['dec'] = locs.dec.to(u.deg).value
     out['type'] = types
-    out['n'] = sersic_index
-    out['half_light_radius'] = hlr
-    out['pa'] = pa
-    out['ba'] = ba
+    out['n'] = sersic_index.astype('f4')
+    out['half_light_radius'] = hlr.astype('f4')
+    out['pa'] = pa.astype('f4')
+    out['ba'] = ba.astype('f4')
     for bandpass in bandpasses:
         mag_thisband = mag + rng_numpy.normal(size=n)
         # sigma of one mag isn't nuts.  But this will be totally uncorrelated
         # in different bands, so we'll get some weird colored objects
-        out[bandpass] = 10.**(-mag_thisband / 2.5)
+        out[bandpass] = (10.**(-mag_thisband / 2.5)).astype('f4')
     return out
 
 

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -332,7 +332,7 @@ def apportion_counts_to_resultants(
         # order enough that either decision would be fine.
         persistence.update(counts_so_far + instrumental_so_far, tnow)
 
-    nweirdpixfrac = np.sum(nlflag) / np.product(nlflag.shape)
+    nweirdpixfrac = np.sum(nlflag) / np.prod(nlflag.shape)
     if nweirdpixfrac > 0:
         log.warning(f'{nweirdpixfrac:5.1e} fraction of pixels have '
                     'observed(corrected) nonlinearity slopes of >1 or <0.  '

--- a/romanisim/persistence.py
+++ b/romanisim/persistence.py
@@ -110,6 +110,9 @@ class Persistence:
         -------
         Current in electron / s in pixels due to past persistence events.
         """
+        if np.ndim(self.t) > 0 and len(self.t) > 0 and (tnow < np.min(self.t)):
+            raise ValueError(
+                'persistence current requested before persistence event?!')
         return fermi(self.x, (tnow - self.t) * 60 * 60 * 24,
                      self.A, self.x0, self.dx, self.alpha, self.gamma)
 

--- a/romanisim/ramp_fit_casertano.pyx
+++ b/romanisim/ramp_fit_casertano.pyx
@@ -12,7 +12,7 @@ cdef int PTABLE_LENGTH = 6
 
 
 cdef inline float get_weight_power(float s):
-    cdef int ise
+    cdef int i
     for i in range(PTABLE_LENGTH):
         if s < PTABLE[0][i]:
             return PTABLE[1][i - 1]
@@ -22,6 +22,7 @@ cdef inline float get_weight_power(float s):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
+@cython.cpow(True)
 cdef inline (float, float, float) fit_one_ramp(
         float [:] resultants, int start, int end, float read_noise,
         float [:] tbar, float [:] tau, int [:] nn):
@@ -60,6 +61,10 @@ cdef inline (float, float, float) fit_one_ramp(
     cdef float kk[2048]
     cdef float slope = 0, slopereadvar = 0, slopepoissonvar = 0
     cdef float tbarmid = (tbar[start] + tbar[end]) / 2
+
+    # Doesn't make sense to fit a ramp with 1 or fewer resultant.  Fail early.
+    if nres <= 1:
+        return (0.0, 0.0, 0.0)
 
     # Casertano+2022 Eq. 44
     # Note we've departed from Casertano+22 slightly;

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -102,9 +102,6 @@ def get_wcs(image, usecrds=True, distortion=None):
     usecrds : bool
         If True, use crds reference distortions rather than galsim.roman
         distortion model.
-    boresight : bool
-        If True, world_pos specifies the location of the telescope boresight;
-        otherwise the location of the science aperture.
 
     Returns
     -------

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -66,9 +66,7 @@ if __name__ == '__main__':
 
     if args.date is not None:
         metadata['exposure']['start_time'] = Time(
-            datetime.datetime(*args.date)).isot
-
-    date = Time(metadata['exposure']['start_time'], format='isot')
+            datetime.datetime(*args.date))
 
     metadata['instrument']['detector'] = f'WFI{args.sca:02d}'
     metadata['instrument']['optical_element'] = args.bandpass


### PR DESCRIPTION
Fix some cosmetic issues and upcoming deprecations.
* types to f4 rather than f8 in catalogs where appropriate
* np.product -> np.prod
* raise an error if you try to get a persistence flux from times _before_ the persistence event occurred
* metadata['exposure']['start_time'] needs to be an astropy Time object.