### PR TITLE
Add or improve tests for various simulator requirements.

### DIFF
--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -377,7 +377,7 @@ def add_read_noise_to_resultants(resultants, tij, read_noise=None, rng=None,
     else:
         rng = galsim.GaussianDeviate(rng)
 
-    noise = np.empty(resultants.shape, dtype='f4')
+    noise = np.zeros(resultants.shape, dtype='f4')
     rng.generate(noise)
     if read_noise is None:
         read_noise = parameters.read_noise

--- a/romanisim/tests/test_catalog.py
+++ b/romanisim/tests/test_catalog.py
@@ -128,5 +128,5 @@ def test_table_catalog(tmp_path):
             > np.median(tgal1['half_light_radius']))
     assert (np.median(tgal1[bands[0]])
             > np.median(tgal2[bands[0]]))
-    log.info('DMS217: Generated parametric distributions of sources with '
-             'different magnitudes and sizes.')
+    log.info('DMS217: successfully generated parametric distributions of '
+             'sources with different magnitudes and sizes.')

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -344,7 +344,7 @@ def test_simulate_counts_generic():
     # mean.
     assert (np.abs(np.mean(im2.array) - np.var(im2.array))
             < 20 * np.sqrt(poisson_rate / npix))
-    log.info('DMS230: successfully include Poisson noise in image.')
+    log.info('DMS230: successfully included Poisson noise in image.')
     im3 = im.copy()
     image.simulate_counts_generic(im3, exptime, dark=sky, zpflux=zpflux)
     # verify that the dark counts don't see the zero point conversion
@@ -424,7 +424,7 @@ def test_simulate_counts():
 
 
 @pytest.mark.soctests
-def test_simulate(tmp_path):
+def test_simulate():
     """Test convolved image generation and L2 simulation framework.
     Demonstrates DMS216: convolved image generation - Level 2
     Demonstrates DMS218: WCS & distortions

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -80,8 +80,8 @@ def test_apportion_counts_to_resultants():
             sdev = np.std(res3[plane_index] - resultants[plane_index])
             assert (np.abs(sdev - read_noise / np.sqrt(len(restij)))
                     < 20 * sdev / np.sqrt(2 * len(counts.ravel())))
-    log.info('DMS229: successfully generated ramp from counts.')
     log.info('DMS220: successfully added read noise to resultants.')
+    log.info('DMS229: successfully generated ramp from counts.')
 
 
 @pytest.mark.soctests

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -59,6 +59,7 @@ def test_tij_to_pij():
 def test_apportion_counts_to_resultants():
     """Test that we can apportion counts to resultants and appropriately add
     read noise to those resultants, fulfilling DMS220.
+    Demonstrates DMS220, 229.
     """
     # we'll skip the linearity tests until new linearity files with
     # inverse coefficients are available in CRDS.
@@ -79,6 +80,7 @@ def test_apportion_counts_to_resultants():
             sdev = np.std(res3[plane_index] - resultants[plane_index])
             assert (np.abs(sdev - read_noise / np.sqrt(len(restij)))
                     < 20 * sdev / np.sqrt(2 * len(counts.ravel())))
+    log.info('DMS229: successfully generated ramp from counts.')
     log.info('DMS220: successfully added read noise to resultants.')
 
 

--- a/romanisim/tests/test_ris_make_utils.py
+++ b/romanisim/tests/test_ris_make_utils.py
@@ -1,0 +1,52 @@
+"""Test ris_make_utils module.
+Routines tested:
+* set_metadata
+* create_catalog
+* simulate_image_file
+"""
+
+import types
+import pytest
+import numpy as np
+from romanisim import ris_make_utils
+import asdf
+import galsim
+
+
+def test_set_metadata():
+    meta = ris_make_utils.set_metadata()
+    assert meta is not None
+    assert len(meta) > 0
+    ris_make_utils.set_metadata(meta, bandpass='F158')
+    assert meta['instrument']['optical_element'] == 'F158'
+
+
+def test_create_catalog(tmp_path):
+    with pytest.raises(ValueError):
+        cat = ris_make_utils.create_catalog()
+    from astropy.table import Table
+    tabpath = tmp_path / 'table.ecsv'
+    tab = Table(np.zeros(1, dtype=[('ra', 'f4')]))
+    tab.write(tabpath)
+    cat = ris_make_utils.create_catalog(catalog_name=tabpath)
+    assert len(cat) == 1
+    cat = ris_make_utils.create_catalog(metadata=ris_make_utils.set_metadata(),
+                                        nobj=1000)
+    assert len(cat) == 1000
+
+
+def test_simulate_image_file(tmp_path):
+    args = types.SimpleNamespace()
+    meta = ris_make_utils.set_metadata()
+    cat = ris_make_utils.create_catalog(meta, nobj=1)
+    rng = None
+    persist = None
+    args.filename = tmp_path / 'im.asdf'
+    args.usecrds = False
+    args.webbpsf = False
+    args.level = 0
+    galsim.roman.n_pix = 100
+    ris_make_utils.simulate_image_file(args, meta, cat)
+    im = asdf.open(args.filename)
+    assert im['roman']['data'].shape == (100, 100)
+    # we made an image

--- a/romanisim/tests/test_ris_make_utils.py
+++ b/romanisim/tests/test_ris_make_utils.py
@@ -39,8 +39,6 @@ def test_simulate_image_file(tmp_path):
     args = types.SimpleNamespace()
     meta = ris_make_utils.set_metadata()
     cat = ris_make_utils.create_catalog(meta, nobj=1)
-    rng = None
-    persist = None
     args.filename = tmp_path / 'im.asdf'
     args.usecrds = False
     args.webbpsf = False

--- a/romanisim/tests/test_ris_make_utils.py
+++ b/romanisim/tests/test_ris_make_utils.py
@@ -28,17 +28,17 @@ def test_create_catalog(tmp_path):
     tabpath = tmp_path / 'table.ecsv'
     tab = Table(np.zeros(1, dtype=[('ra', 'f4')]))
     tab.write(tabpath)
-    cat = ris_make_utils.create_catalog(catalog_name=tabpath)
+    cat = ris_make_utils.create_catalog(catalog_name=tabpath, usecrds=False)
     assert len(cat) == 1
     cat = ris_make_utils.create_catalog(metadata=ris_make_utils.set_metadata(),
-                                        nobj=1000)
+                                        nobj=1000, usecrds=False)
     assert len(cat) == 1000
 
 
 def test_simulate_image_file(tmp_path):
     args = types.SimpleNamespace()
     meta = ris_make_utils.set_metadata()
-    cat = ris_make_utils.create_catalog(meta, nobj=1)
+    cat = ris_make_utils.create_catalog(meta, nobj=1, usecrds=False)
     args.filename = tmp_path / 'im.asdf'
     args.usecrds = False
     args.webbpsf = False

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -5,7 +5,7 @@ from astropy.coordinates import SkyCoord
 from astropy import units as u
 import galsim
 from romanisim import log, wcs, persistence
-import ris_make_utils as ris
+from romanisim import ris_make_utils as ris
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -50,7 +50,9 @@ if __name__ == '__main__':
                 "packages like galsim's roman package or STIPS may better "
                 "serve such purposes.")
 
-    metadata = ris.set_metadata(date=args.date, bandpass=args.bandpass, sca=args.sca, ma_table_number=args.ma_table_number)
+    metadata = ris.set_metadata(date=args.date, bandpass=args.bandpass,
+                                sca=args.sca,
+                                ma_table_number=args.ma_table_number)
 
     if args.radec is not None:
         coord = SkyCoord(ra=args.radec[0] * u.deg, dec=args.radec[1] * u.deg,
@@ -60,7 +62,9 @@ if __name__ == '__main__':
     rng = galsim.UniformDeviate(args.rng_seed)
 
     # Create catalog
-    cat = ris.create_catalog(catalog_name=args.catalog, bandpasses=[args.bandpass], rng=rng, nobj=args.nobj, usecrds=args.usecrds)
+    cat = ris.create_catalog(metadata=metadata, catalog_name=args.catalog,
+                             bandpasses=[args.bandpass], rng=rng,
+                             nobj=args.nobj, usecrds=args.usecrds)
 
     # Create persistence object
     if args.previous is not None:

--- a/scripts/romanisim-make-stack
+++ b/scripts/romanisim-make-stack
@@ -9,7 +9,7 @@ from astropy.time import Time
 import galsim
 from romanisim import wcs, persistence, log, parameters
 from romanisim.parameters import default_parameters_dictionary
-import ris_make_utils as ris
+from romanisim import ris_make_utils as ris
 
 
 def main():
@@ -209,7 +209,8 @@ def main():
                 else:
                     persist = persistence.Persistence()
 
-                ris.simulate_image_file(args, metadata, cat, rng, persist, output=output_file_name)
+                args.filename = output_file_name
+                ris.simulate_image_file(args, metadata, cat, rng, persist)
 
             # Update persistence file if applicable
             if args.persistence:


### PR DESCRIPTION
* DMS217: Parametric source distributions.
* DMS218: Distortion & WCS.
* DMS229: Ramp from counts.
* DMS230: Poisson noise.

A few unrelated changes:
- initialize noise array with zeros instead of empty because galsim wants to cast it before filling it, and can try to cast invalid numbers and emit a warning.
- fix the units on some test_simulate(...) tests to avoid generating sources with 10^20 photons.