### PR TITLE
Update jenkins configuration to run single threaded

### DIFF
--- a/JenkinsfileRT_dev
+++ b/JenkinsfileRT_dev
@@ -48,7 +48,7 @@ pipeline {
                       conda activate romanisim
                       pytest romanisim \
                         --bigdata --slow --basetemp=test_outputs \
-                        -n auto
+                        -n 0  # -n 8 causes problems with CRDS runs?
                    """
                 )
             }


### PR DESCRIPTION
The default Jenkins configuration is causing problems when hitting the CRDS cache, leading to job failures.  This disables the multithreading for the moment.