### PR TITLE
fix weekly CI trigger

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   data:
-    if: (github.repository == 'spacetelescope/romancal' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Weekly CI')))
+    if: (github.repository == 'spacetelescope/romanisim' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Weekly CI')))
     name: Download data
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
the `if: ` block in the weekly CI is checking for the `romancal` repository instead of `romanisim`