### PR TITLE
RCAL-645 Override Reference Files

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -635,7 +635,7 @@ def simulate(metadata, objlist,
         import crds
         refnames_lst = ['readnoise', 'dark', 'gain', 'inverselinearity', 'linearity', 'saturation']
 
-        for key, value in parameters.reference_file_names.items():
+        for key, value in parameters.reference_data.items():
             if (key in refnames_lst) and (value is not None):
                 reffiles[key] = value
                 refnames_lst.remove(key)
@@ -692,17 +692,17 @@ def simulate(metadata, objlist,
         )
         saturation = saturation_model.data[nborder:-nborder, nborder:-nborder]
     else:
-        read_noise = parameters.reference_file_names["readnoise"] \
-            if parameters.reference_file_names["readnoise"] is not None else galsim.roman.read_noise
-        darkrate = (parameters.reference_file_names["dark"] / exptime_tau) \
-            if parameters.reference_file_names["dark"] is not None else galsim.roman.dark_current
-        dark = parameters.reference_file_names["dark"]
-        gain = parameters.reference_file_names["gain"]
-        flat = parameters.reference_file_names["flat"] \
-            if parameters.reference_file_names["flat"] is not None else 1
-        inv_linearity = parameters.reference_file_names["inverselinearity"]
-        linearity = parameters.reference_file_names["linearity"]
-        saturation = parameters.reference_file_names["saturation"]
+        read_noise = parameters.reference_data["readnoise"] \
+            if parameters.reference_data["readnoise"] is not None else galsim.roman.read_noise
+        darkrate = parameters.reference_data["darkcurrent"] \
+            if parameters.reference_data["darkcurrent"] is not None else galsim.roman.dark_current
+        dark = parameters.reference_data["dark"]
+        gain = parameters.reference_data["gain"]
+        flat = parameters.reference_data["flat"] \
+            if parameters.reference_data["flat"] is not None else 1
+        inv_linearity = parameters.reference_data["inverselinearity"]
+        linearity = parameters.reference_data["linearity"]
+        saturation = parameters.reference_data["saturation"]
 
     if rng is None and seed is None:
         seed = 43

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -629,7 +629,7 @@ def simulate(metadata, objlist,
     # and keywords and returns a dictionary with all of the relevant reference
     # data in numpy arrays.
     # should query CRDS for any reference files not specified on the command
-    # line.  
+    # line.
     reffiles = {}
     if usecrds:
         import crds
@@ -700,7 +700,7 @@ def simulate(metadata, objlist,
         gain = parameters.reference_file_names["gain"]
         flat = parameters.reference_file_names["flat"] \
             if parameters.reference_file_names["flat"] is not None else 1
-        inv_linearity = None
+        inv_linearity = parameters.reference_file_names["inverselinearity"]
         linearity = parameters.reference_file_names["linearity"]
         saturation = parameters.reference_file_names["saturation"]
 

--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -26,8 +26,9 @@ default_parameters_dictionary = {
                 },
 }
 
-reference_file_names = {
+reference_data = {
     "dark": None,
+    "darkcurrent": None,
     "distortion": None,
     "flat": None,
     "gain": None,
@@ -63,6 +64,12 @@ ipc_kernel /= np.sum(ipc_kernel)
 
 # V2/V3 coordinates of "center" of WFI array (convention)
 v2v3_wficen = (1546.3846181707652, -892.7916365721071)
+
+# persistence parameter dictionary
+# delete persistence records fainter than 0.01 electron / s
+# e.g., MA table 1 has ~144 s, so this is ~1 electron over the whole exposure.
+persistence = dict(A=0.017, x0=6.0e4, dx=5.0e4, alpha=0.045, gamma=1,
+                   half_well=50000, ignorerate=0.01)
 
 # default saturation level in DN absent reference file information
 saturation = 55000 * u.DN

--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -26,6 +26,16 @@ default_parameters_dictionary = {
                   },
 }
 
+reference_file_names = {
+    "dark": None,
+    "distortion": None,
+    "flat": None,
+    "gain": None,
+    "inverselinearity": None,
+    "linearity": None,
+    "readnoise": None,
+    "saturation": None
+}
 
 # default read noise
 read_noise = 5.0 * u.DN

--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -124,7 +124,7 @@ def create_catalog(metadata=None, catalog_name=None, bandpasses=['F087'],
     if catalog_name is None:
         # Create a catalog from scratch
         # Create wcs object
-        distortion_file = parameters.reference_file_names["distortion"]
+        distortion_file = parameters.reference_data["distortion"]
         if distortion_file is not None:
             dist_model = roman_datamodels.datamodels.DistortionRefModel(distortion_file)
             distortion = dist_model.coordinate_distortion_transform

--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -98,7 +98,7 @@ def create_catalog(metadata=None, catalog_name=None, bandpasses=['F087'],
     if catalog_name is None:
         # Create a catalog from scratch
         # Create wcs object
-        twcs = wcs.get_wcs(metadata, usecrds=usecrds)
+        twcs = wcs.get_wcs(metadata, usecrds=usecrds, distortion=parameters.reference_file_names["distortion"])
 
         if not isinstance(coord, coordinates.SkyCoord):
             coord = twcs.toWorld(galsim.PositionD(*coord))

--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -8,6 +8,7 @@ from astropy import time
 from astropy import coordinates
 import galsim
 from galsim import roman
+import roman_datamodels
 from romanisim import catalog, image, wcs
 from romanisim import parameters
 from romanisim import log
@@ -123,7 +124,13 @@ def create_catalog(metadata=None, catalog_name=None, bandpasses=['F087'],
     if catalog_name is None:
         # Create a catalog from scratch
         # Create wcs object
-        twcs = wcs.get_wcs(metadata, usecrds=usecrds, distortion=parameters.reference_file_names["distortion"])
+        distortion_file = parameters.reference_file_names["distortion"]
+        if distortion_file is not None:
+            dist_model = roman_datamodels.datamodels.DistortionRefModel(distortion_file)
+            distortion = dist_model.coordinate_distortion_transform
+        else:
+            distortion = None
+        twcs = wcs.get_wcs(metadata, usecrds=usecrds, distortion=distortion)
 
         if not isinstance(coord, coordinates.SkyCoord):
             coord = twcs.toWorld(galsim.PositionD(*coord))

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -101,6 +101,8 @@ def get_wcs(image, usecrds=True, distortion=None):
     usecrds : bool
         If True, use crds reference distortions rather than galsim.roman
         distortion model.
+    distortion : astropy.modeling.core.CompoundModel
+        Coordinate distortion transformation parameters
 
     Returns
     -------


### PR DESCRIPTION
Added the ability to provide reference file names instead of calling CRDS for matched reference files via the parameters file. Also allows for overriding with flat values, if not using reference files. 