### PR TITLE
Allow ramp fitting to use pixels marked with bad non-linearity.

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -125,10 +125,11 @@ def make_l2(resultants, ma_table, read_noise=None, gain=None, flat=None,
 
     if linearity is not None:
         # Update data quality array for linearty coefficients
-        dq = np.bitwise_or(dq, linearity.dq)
+        dq |= linearity.dq
 
-    ramppar, rampvar = ramp.fit_ramps_casertano(resultants * gain, dq,
-                                                read_noise * gain, ma_table)
+    ramppar, rampvar = ramp.fit_ramps_casertano(
+        resultants * gain, dq & parameters.dq_do_not_use,
+        read_noise * gain, ma_table)
 
     log.warning('The ramp fitter is unaware of noise from dark current because '
                 'it runs on dark-subtracted images.  We could consider adding '

--- a/romanisim/nonlinearity.py
+++ b/romanisim/nonlinearity.py
@@ -55,7 +55,7 @@ def repair_coefficients(coeffs, dq):
     res[:, m] = nocorrection[:, None]
 
     lin_dq_array = np.zeros(coeffs.shape[1:], dtype=np.uint32)
-    lin_dq_array[m] = parameters.dqbits['nonlinear']
+    lin_dq_array[m] = parameters.dqbits['no_lin_corr']
     dq = np.bitwise_or(dq, lin_dq_array)
     return res, dq
 

--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -77,7 +77,8 @@ saturation = 55000 * u.DN
 # arbitrary constant to add to initial L1 image so that pixels aren't clipped at zero.
 pedestal = 100 * u.DN
 
-dqbits = dict(saturated=2, jump_det=4, nonlinear=2**16)
+dqbits = dict(saturated=2, jump_det=4, nonlinear=2**16, no_lin_corr=2**20)
+dq_do_not_use = dqbits['saturated'] | dqbits['jump_det']
 
 NUMBER_OF_DETECTORS = 18
 

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -142,7 +142,7 @@ def test_linearized_counts_to_resultants():
         # also test that correctly propagate the nonlinearity DQ bits.
         assert np.all(dq[:, :-1, :-1] == dq2[:, :-1, :-1])
         assert np.all(dq2[:, -1, -1] == (dq[:, -1, -1] |
-                                         parameters.dqbits['no_lin_corr'])
+                                         parameters.dqbits['no_lin_corr']))
     log.info('DMS222: successfully applied nonlinearity to resultants.')
 
     artifactdir = os.environ.get('TEST_ARTIFACT_DIR', None)

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -141,7 +141,8 @@ def test_linearized_counts_to_resultants():
         assert np.isclose(medratio, 2.0, atol=1e-6)
         # also test that correctly propagate the nonlinearity DQ bits.
         assert np.all(dq[:, :-1, :-1] == dq2[:, :-1, :-1])
-        assert np.all(dq2[:, -1, -1] == np.bitwise_or(dq[:, -1, -1], parameters.dqbits['nonlinear']))
+        assert np.all(dq2[:, -1, -1] == (dq[:, -1, -1] |
+                                         parameters.dqbits['no_lin_corr'])
     log.info('DMS222: successfully applied nonlinearity to resultants.')
 
     artifactdir = os.environ.get('TEST_ARTIFACT_DIR', None)

--- a/romanisim/tests/test_linear.py
+++ b/romanisim/tests/test_linear.py
@@ -62,8 +62,8 @@ def test_repair_coeffs():
 
     linearity = nonlinearity.NL(lin_coeffs, gain=gain)
 
-    assert linearity.dq[1, 1] == parameters.dqbits['nonlinear']
-    assert linearity.dq[22, 22] == parameters.dqbits['nonlinear']
+    assert linearity.dq[1, 1] == parameters.dqbits['no_lin_corr']
+    assert linearity.dq[22, 22] == parameters.dqbits['no_lin_corr']
     # All other entries should be zero
     assert np.count_nonzero(linearity.dq) == 2
 


### PR DESCRIPTION
This PR allows ramp fitting to proceed on pixels marked as having problematic linearity.

Formerly we had only two DQ bits---saturation and CR.  Ramp fitting ignored any pixel with a DQ bit so that we didn't include these in the ramps.  When we added the nonlinearity DQ bit, this made us stop fitting ramps on all of the pixels with problematic linearity determination, which is not what we want.

This adds a new parameters.dq_do_not_use set of flags that identifies the flags that should be used for determining which resultants to ignore in ramp fitting.

I also changed the name of the dq bit we're using from nonlinear to no_lin_corr, since I think the latter is a better match to what's happening in the simulator at the moment.