### PR TITLE
RCAL-628 SOC Test decorators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ test = [
     'pytest-doctestplus >=0.10.0',
     'pytest-cov >=2.9.0',
     'flake8 >=3.6.0',
+    'metrics_logger >= 0.1.0',
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,5 @@ scipy>=0.0.dev0
 git+https://github.com/spacetelescope/roman_datamodels
 git+https://github.com/spacetelescope/rad
 
+# Testing upstream packages
+git+https://github.com/spacetelescope/metrics_logger

--- a/romanisim/tests/test_catalog.py
+++ b/romanisim/tests/test_catalog.py
@@ -4,6 +4,7 @@ Unit tests for catalog functions.
 
 import os
 import numpy as np
+from metrics_logger.decorators import metrics_logger
 import galsim
 from romanisim import catalog
 from astropy.coordinates import SkyCoord
@@ -35,7 +36,11 @@ def test_make_dummy_catalog():
     assert not cat[0].profile.spectral
 
 
+@metrics_logger("DMS217")
 def test_table_catalog(tmp_path):
+    """Test generation of sources with different magnitudes and sizes
+    Demonstrates DMS217: generate parametric distributions
+    """
     cen = SkyCoord(ra=5 * u.deg, dec=-10 * u.deg)
     radius = 0.2
     nobj = 200

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -27,6 +27,7 @@ import asdf
 import webbpsf
 from astropy.modeling.functional_models import Sersic2D
 import pytest
+from metrics_logger.decorators import metrics_logger
 from romanisim import log
 from roman_datamodels.stnode import WfiScienceRaw, WfiImage
 import romanisim.bandpass
@@ -154,6 +155,7 @@ def central_stamp(im, sz):
               center - szo2: center + szo2 + 1]
 
 
+@metrics_logger("DMS214", "DMS215")
 @pytest.mark.soctests
 def test_image_rendering():
     """Tests for image rendering routines.  This is demonstrates:
@@ -269,6 +271,7 @@ def test_image_rendering():
     # Poisson errors and containing 100k counts.
 
 
+@metrics_logger("DMS218")
 def test_add_objects():
     """Test adding objects to images.
     Demonstrates profile sensitivity to distortion component of DMS218.
@@ -313,7 +316,11 @@ def test_add_objects():
     # the actual ratio was 42.
 
 
+@metrics_logger("DMS230")
 def test_simulate_counts_generic():
+    """Test adding poisson noise to images.
+    Demonstrates DMS230: poisson noise
+    """
     imdict = set_up_image_rendering_things()
     im = imdict['im']
     im.array[:] = 0
@@ -437,11 +444,13 @@ def test_simulate_counts():
     assert np.all(m)
 
 
+@metrics_logger("DMS216", "DMS218", "DMS221", "DMS224")
 @pytest.mark.soctests
 def test_simulate():
     """Test convolved image generation and L2 simulation framework.
     Demonstrates DMS216: convolved image generation - Level 2
     Demonstrates DMS218: WCS & distortions
+    Demonstrates DMS221: cosmic rays
     Demonstrates DMS224: persistence.
     """
     imdict = set_up_image_rendering_things()

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -11,6 +11,7 @@ Routines tested:
 """
 
 import pytest
+from metrics_logger.decorators import metrics_logger
 import numpy as np
 from romanisim import l1, log, parameters, nonlinearity
 import galsim
@@ -56,6 +57,7 @@ def test_tij_to_pij():
             pij, np.diff(np.concatenate(tij), prepend=0) / tij[-1][-1])
 
 
+@metrics_logger("DMS220", "DMS229")
 @pytest.mark.soctests
 def test_apportion_counts_to_resultants():
     """Test that we can apportion counts to resultants and appropriately add
@@ -106,9 +108,11 @@ def test_apportion_counts_to_resultants():
         af.write_to(os.path.join(artifactdir, 'dms229.asdf'))
 
 
+@metrics_logger("DMS222")
 @pytest.mark.soctests
 def test_linearized_counts_to_resultants():
     """Test that we can apportion linearized counts to resultants.
+    Demonstrates DMS222: nonlinearity
     """
     counts = np.random.poisson(100, size=(100, 100))
 
@@ -155,6 +159,7 @@ def test_linearized_counts_to_resultants():
         af.write_to(os.path.join(artifactdir, 'dms222.asdf'))
 
 
+@metrics_logger("DMS225")
 @pytest.mark.soctests
 def test_inject_source_into_ramp():
     """Inject a source into a ramp.
@@ -194,6 +199,7 @@ def test_inject_source_into_ramp():
         af.write_to(os.path.join(artifactdir, 'dms225.asdf'))
 
 
+@metrics_logger("DMS226")
 @pytest.mark.soctests
 def test_ipc():
     """Convolve an image with an IPC kernel.
@@ -221,6 +227,7 @@ def test_ma_table_to_tij():
         assert l1.validate_times(tij)
 
 
+@metrics_logger("DMS227")
 @pytest.mark.soctests
 def test_make_l1_and_asdf(tmp_path):
     """Make an L1 file and save it appropriately.


### PR DESCRIPTION
Added SOC Test decorators for metrics logging via https://github.com/spacetelescope/metrics_logger