### PR TITLE
Fix parallax definition convention.

### DIFF
--- a/romanisim/gaia.py
+++ b/romanisim/gaia.py
@@ -53,10 +53,9 @@ def gaia2romanisimcat(gaiacat, date, refepoch=2016.0, boost_parallax=1,
     newxyz = (
         xyz + rahat * dt * radpermas * pmra + dechat * dt * radpermas * pmdec)
     plx = gaiacat['parallax'].to(u.mas).value * boost_parallax
-    newxyz -= (rahat * earthcoord.dot(rahat) * plx / 2 * radpermas
-               + dechat * earthcoord.dot(dechat) * plx / 2 * radpermas)
+    newxyz -= (rahat * earthcoord.dot(rahat) * plx * radpermas
+               + dechat * earthcoord.dot(dechat) * plx * radpermas)
     # stars move in the opposite direction of the earth -> minus sign
-    # divide by two: parallax is the diameter rather than radius of the circle
     newunitspherical = coordinates.UnitSphericalRepresentation.from_cartesian(
         coordinates.CartesianRepresentation(newxyz))
     newra = newunitspherical.lon

--- a/romanisim/tests/test_gaia.py
+++ b/romanisim/tests/test_gaia.py
@@ -29,9 +29,9 @@ def test_gaia():
         # first source doesn't move it first catalog since it's observed at its
         # epoch and has zero parallax
         assert cats[0][field][0] == fakegaiacat[field][0]
-    # max separation when pm = 0 should be roughly parallax / 2
+    # max separation when pm = 0 should be roughly parallax
     pm0 = (fakegaiacat['pmra'] == 0) & (fakegaiacat['pmdec'] == 0)
-    assert np.all(np.abs(maxsep[pm0] - fakegaiacat['parallax'][pm0] / 2)
+    assert np.all(np.abs(maxsep[pm0] - fakegaiacat['parallax'][pm0])
                   <= fakegaiacat['parallax'][pm0] * 0.01)
     # sources with zero pmra and plx never move
     assert np.all(sep[:, -1] == 0 * u.deg)

--- a/romanisim/tests/test_gaia.py
+++ b/romanisim/tests/test_gaia.py
@@ -32,7 +32,10 @@ def test_gaia():
     # max separation when pm = 0 should be roughly parallax
     pm0 = (fakegaiacat['pmra'] == 0) & (fakegaiacat['pmdec'] == 0)
     assert np.all(np.abs(maxsep[pm0] - fakegaiacat['parallax'][pm0])
-                  <= fakegaiacat['parallax'][pm0] * 0.01)
+                  <= fakegaiacat['parallax'][pm0] * 0.02)
+    # Earth's eccentricity is 1.016 and 1 AU is roughly the
+    # average of the apohelion and perihelion, so we expect differences
+    # here of scale ~0.016; 0.02 gives us some margin.
     # sources with zero pmra and plx never move
     assert np.all(sep[:, -1] == 0 * u.deg)
     # sources with zero parallax have increasing separation


### PR DESCRIPTION
I had previously thought that parallax defined the _diameter_ of the circle stars describe as the earth moves.  In fact it's the radius.  This means that we need to remove a factor of two and a comment.