### PR TITLE
Ensure correct PSF orientation

### DIFF
--- a/docs/romanisim/install.rst
+++ b/docs/romanisim/install.rst
@@ -59,3 +59,5 @@ You may wish to, for example, set up a new python virtual environment
 before running the above, or choose a different directory for
 WebbPSF's data files.
 
+Some users report issues with the FFTW dependency of galsim on Mac Arm
+systems.  See galsim's installation page for hints there.

--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -11,7 +11,6 @@ from galsim import roman
 import roman_datamodels
 from romanisim import catalog, image, wcs
 from romanisim import parameters
-from romanisim import log
 
 
 def merge_nested_dicts(dict1, dict2):

--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -138,9 +138,6 @@ def create_catalog(metadata=None, catalog_name=None, bandpasses=['F087'],
         cat = catalog.make_dummy_table_catalog(
             coord, bandpasses=bandpasses, nobj=nobj, rng=rng)
     else:
-        log.warning('Catalog input will probably not work unless the catalog '
-                    'covers a lot of area or you have thought carefully about '
-                    'the relation between the boresight and the SCA locations.')
         cat = table.Table.read(catalog_name, comment="#", delimiter=" ")
 
     return cat

--- a/romanisim/tests/test_psf.py
+++ b/romanisim/tests/test_psf.py
@@ -16,6 +16,9 @@ class FakeWCS():
         return galsim.CelestialCoord(pos.x * 0.1 * galsim.arcsec,
                                      pos.y * 0.1 * galsim.arcsec)
 
+    def local(self, *args, **kwargs):
+        return galsim.JacobianWCS(0.1, 0, 0, 0.1)
+
 
 def test_make_psf():
     psfs = []


### PR DESCRIPTION
We now use the wcs argument of romanisim.psf.make_psf to attach a WCS to the PSF to ensure that the orientation of the PSF used in the simulation is correct.