### PR TITLE
Minor fix to clarify user-provided position angle instead of roll

### DIFF
--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -38,7 +38,7 @@ except ImportError:
     import roman_datamodels.testing.utils as maker_utils
 
 
-def fill_in_parameters(parameters, coord, roll_ref=0, boresight=True):
+def fill_in_parameters(parameters, coord, pa_aper=0, boresight=True):
     """Add WCS info to parameters dictionary.
 
     Parameters
@@ -50,8 +50,8 @@ def fill_in_parameters(parameters, coord, roll_ref=0, boresight=True):
     coord : astropy.coordinates.SkyCoord or galsim.CelestialCoord
         world coordinates at V2 / V3 ref (boresight or center of WFI CCDs)
 
-    roll_ref : float
-        roll of the V3 axis from north
+    pa_aper : float
+        position angle (North to YIdl) at the aperture V2Ref/V3Ref
 
     boresight : bool
         whether coord is the telescope boresight (V2 = V3 = 0) or the center of
@@ -74,7 +74,9 @@ def fill_in_parameters(parameters, coord, roll_ref=0, boresight=True):
     parameters['wcsinfo']['dec_ref'] = (
         parameters['pointing']['dec_v1'])
 
-    parameters['wcsinfo']['roll_ref'] = roll_ref
+    # Romanisim uses ROLL_REF = PA_APER - V3IdlYAngle
+    V3IdlYAngle = -60 # this value should eventually be taken from the SIAF
+    parameters['wcsinfo']['roll_ref'] = pa_aper - V3IdlYAngle 
 
     if boresight:
         parameters['wcsinfo']['v2_ref'] = 0
@@ -83,10 +85,8 @@ def fill_in_parameters(parameters, coord, roll_ref=0, boresight=True):
         from .parameters import v2v3_wficen
         parameters['wcsinfo']['v2_ref'] = v2v3_wficen[0]
         parameters['wcsinfo']['v3_ref'] = v2v3_wficen[1]
-        parameters['wcsinfo']['roll_ref'] = (
-            parameters['wcsinfo'].get('roll_ref', 0) + 60)
 
-
+        
 def get_wcs(image, usecrds=True, distortion=None):
     """Get a WCS object for a given sca or set of CRDS parameters.
 

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -37,7 +37,7 @@ if __name__ == '__main__':
                         help='ra and dec (deg)', default=None)
     parser.add_argument('--rng_seed', type=int, default=None)
     parser.add_argument('--roll', type=float, default=0,
-                        help='Roll angle for the instrument.')
+                        help='Position angle (North towards YIdl) measured at the V2Ref/V3Ref of the aperture used.')
     parser.add_argument('--sca', type=int, default=7, help='SCA to simulate')
     parser.add_argument('--usecrds', action='store_true',
                         help='Use CRDS for distortion map')
@@ -69,7 +69,7 @@ if __name__ == '__main__':
     if args.radec is not None:
         coord = SkyCoord(ra=args.radec[0] * u.deg, dec=args.radec[1] * u.deg,
                          frame='icrs')
-        wcs.fill_in_parameters(metadata, coord, boresight=args.boresight, roll_ref=args.roll)
+        wcs.fill_in_parameters(metadata, coord, boresight=args.boresight, pa_aper=args.roll)
 
     rng = galsim.UniformDeviate(args.rng_seed)
 

--- a/scripts/romanisim-make-stack
+++ b/scripts/romanisim-make-stack
@@ -207,7 +207,7 @@ def main():
                 coord = SkyCoord(ra=float(entry['RA']) * u.deg, dec=float(entry['DEC']) * u.deg,
                                  frame='icrs')
                 wcs.fill_in_parameters(metadata, coord, boresight=args.boresight,
-                                       roll_ref=float(entry['PA']))
+                                       pa_aper=float(entry['PA']))
 
                 # Set metadata
                 metadata = ris.set_metadata(meta=metadata,


### PR DESCRIPTION
After some testing and discussion, it has become clear(er) that the user-provided ```--roll``` argument is really the position angle measured at the aperture's V2Ref/V3Ref (measured from North to YIdl). The handling of this value in ```wcs.py``` was also fixed for the case where the aperture used is BORESIGHT. 

Note that the code in ```wcs.py``` converts this value to ```roll_ref```, which is defined as the angle from North to V3 (towards East) measured at the aperture V2Ref/V3Ref, but from a user perspective, it makes more sense to specify the position angle of the aperture on the sky, hence the clarification provided here.