### PR TITLE
Regtest maker functions

### DIFF
--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -19,7 +19,15 @@ read_pattern = {1: [[1 + x for x in range(8)],
                 3: [[1 + x for x in range(25)],
                     [26 + x for x in range(8)],
                     [34],
-                    [35 + x for x in range(14)]]
+                    [35 + x for x in range(14)]],
+                109: [[1], [2, 3], [5, 6, 7], [10, 11, 12, 13],
+                      [15, 16, 17, 18, 19, 20], [21, 22, 23, 24, 25, 26],
+                      [27, 28, 29, 30, 31, 32], [33, 34, 35, 36, 37, 38],
+                      [39, 40, 41, 42, 43], [44]],
+                110: [[1], [2, 3, 4], [5, 6, 7], [8, 9, 10], [11, 12, 13],
+                      [14, 15, 16], [17, 18, 19], [20, 21, 22], [23, 24, 25],
+                      [26, 27, 28], [29, 30, 31], [32, 33, 34], [35, 36, 37],
+                      [38, 39, 40], [41, 42, 43], [44]],
                 }
 
 default_parameters_dictionary = {
@@ -40,6 +48,10 @@ default_parameters_dictionary = {
                 'v2_ref': 0,
                 'v3_ref': 0,
                 'roll_ref': 0,
+                'vparity': -1,
+                'v3yangle': -60.0,
+                # I don't know what vparity and v3yangle should really be,
+                # but they are always -1 and -60 in existing files.
                 },
     'aperture': {'name': 'WFI_CEN',
                  'position_angle': 0

--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -243,6 +243,17 @@ def simulate_image_file(args, metadata, cat, rng=None, persist=None):
         im['meta']['observation'].update(**obsdata)
     im['meta']['filename'] = stnode.Filename(basename)
 
+    pretend_spectral = getattr(args, 'pretend_spectral', None)
+    if args.pretend_spectral is not None:
+        im['meta']['exposure']['type'] = (
+            'WFI_' + args.pretend_spectral.upper())
+        im['meta']['instrument']['optical_element'] = (
+            args.pretend_spectral.upper())
+
+    drop_extra_dq = getattr(args, 'drop_extra_dq', False)
+    if drop_extra_dq:
+        romanisimdict.pop('dq')
+
     # Write file
     af = asdf.AsdfFile()
     af.tree = {'roman': im, 'romanisim': romanisimdict}

--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -244,7 +244,7 @@ def simulate_image_file(args, metadata, cat, rng=None, persist=None):
     im['meta']['filename'] = stnode.Filename(basename)
 
     pretend_spectral = getattr(args, 'pretend_spectral', None)
-    if args.pretend_spectral is not None:
+    if pretend_spectral is not None:
         im['meta']['exposure']['type'] = (
             'WFI_' + args.pretend_spectral.upper())
         im['meta']['instrument']['optical_element'] = (

--- a/scripts/romancal_make_regtest_l1s.sh
+++ b/scripts/romancal_make_regtest_l1s.sh
@@ -1,0 +1,30 @@
+# r0000101001001001001_01101_0001_WFI01 - default for most steps
+# r0000201001001001001_01101_0001_WFI01 - equivalent for spectroscopic data
+# r0000101001001001001_01101_0002_WFI01 - a second resample exposure, only cal step needed
+# r0000101001001001001_01101_0003_WFI01 - for ramp fitting; truncated image
+# r0000201001001001001_01101_0003_WFI01 - for ramp fitting; truncated spectroscopic
+#                                         we need only darkcurrent & ramp fit for these
+#
+# r0000101001001001001_01101_0004_WFI01 - ma_table 110, 16 resultants file
+# r0000201001001001001_01101_0004_WFI01 - ma_table 110, 16 resultant file, spectroscopic
+
+# note that the "spectroscopic" files are really imaging files where the only
+# thing that has been updated is the optical_element and exposure.type.
+# The MA tables are also supposed to be slightly different (frame time is different?)
+# but I haven't done anything here.
+
+# default image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --webbpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_01101_0001_WFI01_uncal.asdf &
+# different location, different activity
+romanisim-make-image --radec 270.00 66.01 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --webbpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_01101_0002_WFI01_uncal.asdf &
+# default spectroscopic image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --webbpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_01101_0001_WFI01_uncal.asdf --pretend-spectral GRISM &
+# truncated image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --webbpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_01101_0003_WFI01_uncal.asdf --truncate 6 &
+# truncated spectroscopic image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --webbpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_01101_0003_WFI01_uncal.asdf --truncate 6 --pretend-spectral GRISM &
+# 16 resultant image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --webbpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_01101_0004_WFI01_uncal.asdf &
+# truncated spectroscopic image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --webbpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_01101_0004_WFI01_uncal.asdf --pretend-spectral GRISM &
+

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -45,6 +45,11 @@ if __name__ == '__main__':
                         help='Use webbpsf for PSF')
     parser.add_argument('--truncate', type=int, default=None, help=(
         'If set, truncate the MA table at given number of resultants.'))
+    parser.add_argument('--pretend-spectral', type=str, default=None, help=(
+        'Pretend the image is spectral.  exposure.type and instrument.element '
+        'are updated to be grism / prism.'))
+    parser.add_argument('--drop-extra-dq', default=False, action='store_true',
+                        help=('Do not store the optional simulated dq array.'))
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR adds a few new features useful for making regression test files for romancal.
* It adds the read patterns for some new MA tables used in the regression tests.
* It adds a 'pretend-spectral' CLI option to write in the metadata that the image is dispersed even when it's not.
* It adds a new argument to remove the extra romanisim "truth" DQ image, which can otherwise take up most of the data volume of the file.
* It adds a script to generate a minimal set of L1 files that are needed for the regression tests.
* It fills out the v3parity and v3yangle keywords to constant values of -1 and -60.  Confusingly, the exposure level pipeline does not need these keywords to make WCSes, but the mosaic pipeline does.  It's not obvious to me that that makes sense (i.e., maybe we should be doing something differently in either the exposure level or mosaic level pipelines), but I'm not going to worry about it more as part of this PR.

