### PR TITLE
Fill out target metadata stanza

### DIFF
--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -258,4 +258,4 @@ def simulate_image_file(args, metadata, cat, rng=None, persist=None):
     af = asdf.AsdfFile()
     af.tree = {'roman': im, 'romanisim': romanisimdict}
 
-    af.write_to(args.filename)
+    af.write_to(open(args.filename, 'wb'))

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -214,6 +214,18 @@ def add_more_metadata(metadata):
     metadata['exposure']['duration'] = openshuttertime
     metadata['exposure']['read_pattern'] = read_pattern
     # integration_start?  integration_end?  nints = 1?  ...
+    target = metadata['target']
+    target['type'] = 'FIXED'
+    target['ra'] = parameters['wcsinfo']['ra_ref']
+    target['dec'] = parameters['wcsinfo']['dec_ref']
+    target['ra_uncertainty'] = 0
+    target['dec_uncertainty'] = 0
+    target['proper_motion_ra'] = 0
+    target['proper_motion_dec'] = 0
+    target['proper_motion_epoch'] = 'J2000'
+    target['proposer_ra'] = target['ra']
+    target['proposer_dec'] = target['dec']
+    target['source_type'] = 'EXTENDED'
 
 
 def king_profile(r, rc, rt):

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -214,17 +214,21 @@ def add_more_metadata(metadata):
     metadata['exposure']['duration'] = openshuttertime
     metadata['exposure']['read_pattern'] = read_pattern
     # integration_start?  integration_end?  nints = 1?  ...
+
+    if 'target' not in metadata.keys():
+        metadata['target'] = {}
     target = metadata['target']
     target['type'] = 'FIXED'
-    target['ra'] = parameters['wcsinfo']['ra_ref']
-    target['dec'] = parameters['wcsinfo']['dec_ref']
+    if 'wcsinfo' in metadata.keys():
+        target['ra'] = metadata['wcsinfo']['ra_ref']
+        target['dec'] = metadata['wcsinfo']['dec_ref']
+        target['proposer_ra'] = target['ra']
+        target['proposer_dec'] = target['dec']
     target['ra_uncertainty'] = 0
     target['dec_uncertainty'] = 0
     target['proper_motion_ra'] = 0
     target['proper_motion_dec'] = 0
     target['proper_motion_epoch'] = 'J2000'
-    target['proposer_ra'] = target['ra']
-    target['proposer_dec'] = target['dec']
     target['source_type'] = 'EXTENDED'
 
 

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -93,7 +93,6 @@ def fill_in_parameters(parameters, coord, pa_aper=0, boresight=True):
     parameters['aperture']['position_angle'] = pa_aper
 
 
-        
 def get_wcs(image, usecrds=True, distortion=None):
     """Get a WCS object for a given sca or set of CRDS parameters.
 


### PR DESCRIPTION
This adds some values to the target metadata stanza.  romanisim usually just gets an ra/dec as input, so the only values we can meaningfully fill out are those ra/dec.  But there are vaguely reasonable values to which one can set many of the other values as well.