### PR TITLE
Change L2 units to DN/s reflecting changes to L2 schema in rad.

### DIFF
--- a/docs/romanisim/l2.rst
+++ b/docs/romanisim/l2.rst
@@ -15,6 +15,5 @@ This is a fairly faithful representation of how level two image construction wor
 
 * We have a simplistic saturation treatment, just clipping resultants that exceed
   the saturation level to the saturation level and throwing a flag.
-* We do not include dark counts as part of the Poisson noise term in the ramp fitting.
 
 .. automodapi:: romanisim.ramp

--- a/docs/romanisim/parameters.rst
+++ b/docs/romanisim/parameters.rst
@@ -1,12 +1,23 @@
 Parameters
 ==========
 
-The parameters module contains a few useful constants describing the Roman telescope.  At present these consist only of:
+The parameters module contains useful constants describing the Roman
+telescope.  These include:
 
 * the default read noise when CRDS is not used
 * the number of border pixels
-* the specification of the read indices going into resultants for a fiducial L1 image
-* the read time.
+* the specification of the read indices going into resultants for a
+  fiducial L1 image for a handful of MA tables
+* the read time
+* the default saturation limit
+* the default IPC kernel
+* the definition of the reference V2/V3 location in the focal plane to
+  which to place the given ra/dec
+* the default persistence parameters
+* the default cosmic ray parameters
+
+These values can be overridden by specifying a yaml config file on the
+command line to romanisim-make-image.
 
 .. automodapi:: romanisim.parameters
 

--- a/docs/romanisim/psf.rst
+++ b/docs/romanisim/psf.rst
@@ -3,7 +3,7 @@ Point Spread Function Modeling
 
 The simulator has two mechanisms for point source modeling.  The first uses the galsim implementation of the Roman point spread function; for more information, see the galsim Roman documentation.  The second uses the webbpsf package to make a model of the Roman PSF.
 
-In the current implementation, the simulator uses a spatially constant, achromatic bandpass for each filter when using webbpsf.  That is, the PSF is not modeled as varying across each SCA, nor does the PSF vary depending on the spectrum of the source being rendered.  However, it seems straightforward to implement either of these modes in the context of galsim, albeit at some computational expense.
+In the current implementation, the simulator uses a linearly varying, achromatic bandpass for each filter when using webbpsf.  That is, the PSF does not vary depending on the spectrum of the source being rendered.  However, it seems straightforward to implement either of these modes in the context of galsim, albeit at some computational expense.
 
 When using the galsim PSF, galsim's "photon shooting" mode is used for efficient rendering of chromatic sources.  When using webbpsf, FFTs are used to to do the convolution of the intrinsic source profile with the PSF and pixel grid of the instrument.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,11 @@ dependencies = [
     'crds >=10.3.1',
     'defusedxml >=0.5.0',
     'galsim >=2.5.1',
-    'rad >=0.18.0',
-    'roman_datamodels >=0.18.0',
+    # 'rad >=0.18.0',
+    # 'roman_datamodels >=0.18.0',
+    'rad @ git+https://github.com/spacetelescope/rad.git',
+    'roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git',
+    # dev versions of rad / roman_datamodels until released with DN/s units.
     'gwcs >=0.18.1',
     'jsonschema >=4.8',
     'numpy >=1.22',

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -90,11 +90,11 @@ def make_l2(resultants, read_pattern, read_noise=None, gain=None, flat=None,
 
     Returns
     -------
-    im : galsim.Image
+    im : np.ndarray
         best fitting slopes
-    var_rnoise : galsim.Image
+    var_rnoise : np.ndarray
         variance in slopes from read noise
-    var_poisson : galsim.Image
+    var_poisson : np.ndarray
         variance in slopes from source noise
     """
 

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -130,6 +130,9 @@ def make_l2(resultants, read_pattern, read_noise=None, gain=None, flat=None,
     if darkrate is not None:
         ramppar[..., 1] -= darkrate
 
+    if isinstance(gain, u.Quantity):
+        gain = gain.value  # no values make sense except for electron / DN
+
     # The ramp fitter is not presently unit-aware; fix up the units by hand.
     # To do this right the ramp fitter should be made unit aware.
     # It takes a bit of work to get this right because we use the fact
@@ -137,9 +140,9 @@ def make_l2(resultants, read_pattern, read_noise=None, gain=None, flat=None,
     # which isn't true as soon as things start having units and requires
     # special handling.  And we use read_time without units a lot throughout
     # the code base.
-    slopes = ramppar[..., 1] * u.electron / u.s
-    readvar = rampvar[..., 0, 1, 1] * (u.electron / u.s)**2
-    poissonvar = rampvar[..., 1, 1, 1] * (u.electron / u.s)**2
+    slopes = ramppar[..., 1] / gain * u.DN / u.s
+    readvar = rampvar[..., 0, 1, 1] / gain * (u.DN / u.s)**2
+    poissonvar = rampvar[..., 1, 1, 1] / gain * (u.DN / u.s)**2
 
     if flat is not None:
         flat = np.clip(flat, 1e-9, np.inf)

--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -9,10 +9,6 @@ webbpsf, which takes a very similar overall approach.
 galsim's InterpolatedImage class makes this straightforward.  Future work
 should consider the following:
 
-* how do we want to deal with PSF variation over the field?  Can we be more
-  efficient than making a new InterpolatedImage at each location based on some
-  e.g. quadratic approximation to the PSF's variation with location in an SCA?
-
 * how do we want to deal with the dependence of the PSF on the source SED?
   It's possible I can just subclass ChromaticObject and implement
   evaluateAtWavelength, possibly also stealing the _shoot code from

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -83,7 +83,7 @@ def test_make_l2():
     slopes, readvar, poissonvar = image.make_l2(
         resultants, read_pattern,
         gain=gain, flat=1, darkrate=0)
-    assert np.allclose(slopes, 1 / parameters.read_time / 4 * u.electron / u.s)
+    assert np.allclose(slopes, 1 / parameters.read_time / 4 * u.DN / u.s)
     assert np.all(np.array(slopes.shape) == np.array(readvar.shape))
     assert np.all(np.array(slopes.shape) == np.array(poissonvar.shape))
     assert np.all(readvar >= 0)


### PR DESCRIPTION
This changes the L2 units to be DN/s instead of e/s by dividing by the gain.  This is to support the corresponding changes to rad.