### PR TITLE
Allow SCA -1 to indicate that multiple images should be made.

### DIFF
--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -152,7 +152,7 @@ def make_psf(sca, filter_name, wcs=None, webbpsf=True, pix=None,
                             pix=pix, chromatic=chromatic, **kw)
     elif pix is not None:
         raise ValueError('cannot set both pix and variable')
-    buf = 40
+    buf = 50
     # WebbPSF complains if we get too close to (0, 0) for some reason.
     # For other corners one can go to within a fraction of a pixel.
     corners = dict(

--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -4,6 +4,7 @@
 from copy import deepcopy
 import os
 import re
+import numpy as np
 import asdf
 from astropy import table
 from astropy import time
@@ -13,7 +14,7 @@ from galsim import roman
 import roman_datamodels
 from roman_datamodels import stnode
 from romanisim import catalog, image, wcs
-from romanisim import parameters
+from romanisim import parameters, log
 
 
 def merge_nested_dicts(dict1, dict2):
@@ -148,6 +149,17 @@ def create_catalog(metadata=None, catalog_name=None, bandpasses=['F087'],
             coord, bandpasses=bandpasses, nobj=nobj, rng=rng)
     else:
         cat = table.Table.read(catalog_name, comment="#", delimiter=" ")
+        bandpass = [f for f in cat.dtype.names if f[0] == 'F']
+        bad = np.zeros(len(cat), dtype='bool')
+        for b in bandpass:
+            bad |= ~np.isfinite(cat[b])
+            if hasattr(cat[b], 'mask'):
+                bad |= cat[b].mask
+        cat = cat[~bad]
+        nbad = np.sum(bad)
+        if nbad > 0:
+            log.info(f'Removing {nbad} catalog entries with non-finite or '
+                     'masked fluxes.')
 
     return cat
 
@@ -251,7 +263,7 @@ def simulate_image_file(args, metadata, cat, rng=None, persist=None):
             args.pretend_spectral.upper())
 
     drop_extra_dq = getattr(args, 'drop_extra_dq', False)
-    if drop_extra_dq:
+    if drop_extra_dq and ('dq' in romanisimdict):
         romanisimdict.pop('dq')
 
     # Write file

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -384,3 +384,22 @@ def wcs_from_fits_header(header):
     gw.bounding_box = ((-0.5, nx - 0.5), (-0.5, ny - 0.5))
 
     return gw
+
+
+def convert_wcs_to_gwcs(wcs):
+    """Convert a GalSim WCS object into a GWCS object.
+
+    Parameters
+    ----------
+    wcs : gwcs.wcs.WCS or wcs.GWCS
+        input WCS to convert
+
+    Returns
+    -------
+    wcs.GWCS corresponding to wcs.
+    """
+    if isinstance(wcs, GWCS):
+        return wcs.wcs
+    else:
+        # make a gwcs WCS from a galsim.roman WCS
+        return wcs_from_fits_header(wcs.header.header)

--- a/scripts/romancal_make_regtest_l1s.sh
+++ b/scripts/romancal_make_regtest_l1s.sh
@@ -28,3 +28,4 @@ romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --ca
 # truncated spectroscopic image
 romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --webbpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_01101_0004_WFI01_uncal.asdf --pretend-spectral GRISM &
 
+wait

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -8,6 +8,60 @@ from astropy import units as u
 import galsim
 from romanisim import log, wcs, persistence, parameters
 from romanisim import ris_make_utils as ris
+from copy import copy
+
+
+def go(args):
+    if args.config is not None:
+        # Open and parse overrides file
+        with open(args.config, "r") as config_file:
+            config = yaml.safe_load(config_file)
+            combo_dict = parameters.__dict__
+            ris.merge_nested_dicts(combo_dict, config)
+            parameters.__dict__.update(combo_dict)
+    elif args.usecrds:
+        # don't use default values
+        for k in parameters.reference_data:
+            parameters.reference_data[k] = None
+
+    if args.sca == -1:
+        # simulate all 18 SCAs sequentially
+        origfilename = copy(args.filename)
+        origprevious = copy(args.previous)
+        for i in range(1, 19):
+            args.sca = i
+            args.filename = origfilename.format(f'WFI{args.sca:02d}')
+            if origprevious is not None:
+                args.previous = origprevious.format(f'WFI{args.sca:02d}')
+            go(args)
+        return
+
+    metadata = ris.set_metadata(
+        date=args.date, bandpass=args.bandpass,
+        sca=args.sca, ma_table_number=args.ma_table_number,
+        truncate=args.truncate)
+
+    if args.radec is not None:
+        coord = SkyCoord(ra=args.radec[0] * u.deg, dec=args.radec[1] * u.deg,
+                         frame='icrs')
+        wcs.fill_in_parameters(metadata, coord, boresight=args.boresight, pa_aper=args.roll)
+
+    rng = galsim.UniformDeviate(args.rng_seed)
+
+    # Create catalog
+    cat = ris.create_catalog(metadata=metadata, catalog_name=args.catalog,
+                             bandpasses=[args.bandpass], rng=rng,
+                             nobj=args.nobj, usecrds=args.usecrds)
+
+    # Create persistence object
+    if args.previous is not None:
+        persist = persistence.Persistence.read(args.previous)
+    else:
+        persist = persistence.Persistence()
+
+    # Simulate image and write to file
+    ris.simulate_image_file(args, metadata, cat, rng, persist)
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -61,40 +115,4 @@ if __name__ == '__main__':
                 "packages like galsim's roman package or STIPS may better "
                 "serve such purposes.")
 
-    if args.config is not None:
-        # Open and parse overrides file
-        with open(args.config, "r") as config_file:
-            config = yaml.safe_load(config_file)
-            combo_dict = parameters.__dict__ 
-            ris.merge_nested_dicts(combo_dict, config)
-            parameters.__dict__.update(combo_dict)
-    elif args.usecrds:
-        # don't use default values
-        for k in parameters.reference_data:
-            parameters.reference_data[k] = None
-
-    metadata = ris.set_metadata(
-        date=args.date, bandpass=args.bandpass,
-        sca=args.sca, ma_table_number=args.ma_table_number,
-        truncate=args.truncate)
-    
-    if args.radec is not None:
-        coord = SkyCoord(ra=args.radec[0] * u.deg, dec=args.radec[1] * u.deg,
-                         frame='icrs')
-        wcs.fill_in_parameters(metadata, coord, boresight=args.boresight, pa_aper=args.roll)
-
-    rng = galsim.UniformDeviate(args.rng_seed)
-
-    # Create catalog
-    cat = ris.create_catalog(metadata=metadata, catalog_name=args.catalog,
-                             bandpasses=[args.bandpass], rng=rng,
-                             nobj=args.nobj, usecrds=args.usecrds)
-
-    # Create persistence object
-    if args.previous is not None:
-        persist = persistence.Persistence.read(args.previous)
-    else:
-        persist = persistence.Persistence()
-
-    # Simulate image and write to file
-    ris.simulate_image_file(args, metadata, cat, rng, persist)
+    go(args)


### PR DESCRIPTION
This PR adds a few assorted romanisim features:
- specifying SCA -1 to romanisim-make-image means looping over all 18 detectors
- Use a seed for the flat field implementation rather than making a separate draw for the flat field, to enable deterministic output.
- Improve the handling of WCS in output products.
- Instantiate the PSFs a little further from the corners of the WFI detectors
- Handle NaNs in positions and fluxes in catalogs by ignoring these sources.