### PR TITLE
Use numerical inverse to improve WCS accuracy

### DIFF
--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -281,7 +281,8 @@ class GWCS(galsim.wcs.CelestialWCS):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            x, y = self.wcs.world_to_pixel(r1, d1)
+            # x, y = self.wcs.world_to_pixel(r1, d1)
+            x, y = self.wcs.numerical_inverse(r1, d1)
 
         if np.ndim(ra) == np.ndim(dec) == 0:
             return x[0], y[0]


### PR DESCRIPTION
There is an issue with the distortion reference files in CRDS such that wcs.world_to_pixel(wcs.pixel_to_world(...)) only inverts at the 0.05 pix level.  That makes it impossible to do astrometry better than ~0.05 pix.  This replaces wcs.world_to_pixel with wcs.numerical_inverse to avoid this issue.  This is slightly slower, so we will restore the original approach when the reference file issue is resolved.