### PR TITLE
Truncate some too-long dummy metadata strings.

### DIFF
--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -231,6 +231,20 @@ def add_more_metadata(metadata):
     target['proper_motion_epoch'] = 'J2000'
     target['source_type'] = 'EXTENDED'
 
+    # there are a few metadata keywords that have problematic, too-long
+    # defaults in RDM.
+    # program.category
+    # ephemeris.ephemeris_reference_frame
+    # guidestar.gs_epoch
+    # this truncates these to the maximum allowed characters.  Alternative
+    # solutions would include doing things like:
+    #   making the roman_datamodels defaults archivable
+    #   making the roman_datamodels validation check lengths of strings
+    metadata['program']['category'] = metadata['program']['category'][:6]
+    metadata['ephemeris']['ephemeris_reference_frame'] = (
+        metadata['ephemeris']['ephemeris_reference_frame'][:10])
+    metadata['guidestar']['gs_epoch'] = metadata['guidestar']['gs_epoch'][:10]
+
 
 def king_profile(r, rc, rt):
     """Compute the King (1962) profile.


### PR DESCRIPTION
There are a handful of dummy strings in from the roman_datamodels maker utilities that are too long to be parsed by the archive.  We truncate those here to be be shorter.

We could consider making the defaults for these strings fit within the archive schema lengths in roman_datamodels or having validation code check these string lengths.  That would avoid this sort of issue.