### PR TITLE
Variances should be divided by gain**2, rather than gain.

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -141,8 +141,8 @@ def make_l2(resultants, read_pattern, read_noise=None, gain=None, flat=None,
     # special handling.  And we use read_time without units a lot throughout
     # the code base.
     slopes = ramppar[..., 1] / gain * u.DN / u.s
-    readvar = rampvar[..., 0, 1, 1] / gain * (u.DN / u.s)**2
-    poissonvar = rampvar[..., 1, 1, 1] / gain * (u.DN / u.s)**2
+    readvar = rampvar[..., 0, 1, 1] / gain**2 * (u.DN / u.s)**2
+    poissonvar = rampvar[..., 1, 1, 1] / gain**2 * (u.DN / u.s)**2
 
     if flat is not None:
         flat = np.clip(flat, 1e-9, np.inf)


### PR DESCRIPTION
When make_l2 was converted to report units in DN/s rather than electron/s, a bug was introduced where the variances were divided by the gain rather than the square of the gain.  This PR fixes that bug.