### PR TITLE
Use WFI_XY_FULL as the aperture instead of WFI_CEN.

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -771,6 +771,7 @@ def simulate(metadata, objlist,
     counts, simcatobj = simulate_counts(
         image_mod.meta, objlist, rng=rng, usecrds=usecrds, darkrate=darkrate,
         webbpsf=webbpsf, flat=flat, psf_keywords=psf_keywords)
+    util.update_aperture_and_wcsinfo_metadata(image_mod.meta, counts.wcs)
     if level == 0:
         im = dict(data=counts.array, meta=dict(image_mod.meta.items()))
     else:

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -211,22 +211,30 @@ def make_wcs(targ_pos,
     ra_ref = targ_pos.ra.to(u.deg).value
     dec_ref = targ_pos.dec.to(u.deg).value
 
-    # v2_ref, v3_ref are in arcsec, but RotationSequence3D wants degrees.
+    # v2_ref, v3_ref are in arcsec, but RotationSequence3D wants degrees,
+    # so start by scaling by 3600.
     rot = models.RotationSequence3D(
         [v2_ref / 3600, -v3_ref / 3600, roll_ref, dec_ref, -ra_ref], 'zyxyz')
 
-    # distortion takes pixels to V2V3
-    # V2V3 are in arcseconds, while SphericalToCartesian expects degrees.
-    model = (distortion | (models.Scale(1 / 3600) & models.Scale(1 / 3600))
-             | gwcs.geometry.SphericalToCartesian(wrap_lon_at=wrap_v2_at)
-             | rot
-             | gwcs.geometry.CartesianToSpherical(wrap_lon_at=wrap_lon_at))
-    model.name = 'pixeltosky'
+    # V2V3 are in arcseconds, while SphericalToCartesian expects degrees,
+    # so again start by scaling by 3600
+    tel2sky = ((models.Scale(1 / 3600) & models.Scale(1 / 3600))
+                | gwcs.geometry.SphericalToCartesian(wrap_lon_at=wrap_v2_at)
+                | rot
+                | gwcs.geometry.CartesianToSpherical(wrap_lon_at=wrap_lon_at))
+    tel2sky.name = 'v23tosky'
+
     detector = cf.Frame2D(name='detector', axes_order=(0, 1),
                           unit=(u.pix, u.pix))
+    v2v3 = cf.Frame2D(name="v2v3", axes_order=(0, 1),
+        axes_names=("v2", "v3"), unit=(u.arcsec, u.arcsec))
     world = cf.CelestialFrame(reference_frame=astropy.coordinates.ICRS(),
                               name='world')
-    return gwcs.wcs.WCS(model, input_frame=detector, output_frame=world)
+
+    pipeline = [gwcs.wcs.Step(detector, distortion),
+                gwcs.wcs.Step(v2v3, tel2sky),
+                gwcs.wcs.Step(world, None)]
+    return gwcs.wcs.WCS(pipeline)
 
 
 class GWCS(galsim.wcs.CelestialWCS):


### PR DESCRIPTION
This PR updates the aperture.name, wcsinfo.v2_ref, wcsinfo.v3_ref, wcsinfo.ra_ref, wcsinfo.dec_ref to use the WFI_XY_FULL apertures rather than the WFI_CEN that I have used thus far.

This required a little more work than I expected since I needed to update the WCS object to separate out the distortion and rotation bits of the WCS pipeline, so that we could later use the distortion bit to figure out v2/v3 ref.

Some notes:
* In the SIAF, the names are like WFI01_FULL, but in rad, they are WFI_01_FULL.  It seems unlikely that that difference is intentional?  I have followed RAD since doing the opposite leads to validation errors.
https://github.com/spacetelescope/rad/blob/main/src/rad/resources/schemas/aperture-1.0.0.yaml#L15-L21 https://github.com/spacetelescope/pysiaf/blob/main/pysiaf/prd_data/Roman/roman_siaf.xml#L13
* I have not added an explicit dependency on pysiaf.  I want to guarantee consistency with the reference files from CRDS I am using.  I don't want to generate files with an old context or something and have a set of distortion files that are inconsistent with the centers in the wcsinfo.
* This does not change the actual WCSes; the WCS is an alternative parameterization of the same set of rotations and distortions as the old WCSes.  This only matches the expectation that the aperture and reference points are on each detector, but I note that it's not atypical for big mosaics with e.g. DECam to have CRPIX / CRVAL corresponding to the boresight and way off each individual detector, which seems like the comparable situation here.