### PR TITLE
Document feature for generating images with all SCAs

### DIFF
--- a/docs/romanisim/running.rst
+++ b/docs/romanisim/running.rst
@@ -31,7 +31,7 @@ this functionality::
       --catalog CATALOG     input catalog (csv) (default: None)
       --radec RADEC RADEC   ra and dec (deg) (default: None)
       --bandpass BANDPASS   bandpass to simulate (default: F087)
-      --sca SCA             SCA to simulate (default: 7)
+      --sca SCA             SCA to simulate (default: 7). Use -1 to generate images for all SCAs.
       --usecrds             Use CRDS for distortion map (default: False)
       --webbpsf             Use webbpsf for PSF (default: False)
       --date DATE [DATE ...]

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -92,7 +92,7 @@ if __name__ == '__main__':
     parser.add_argument('--rng_seed', type=int, default=None)
     parser.add_argument('--roll', type=float, default=0,
                         help='Position angle (North towards YIdl) measured at the V2Ref/V3Ref of the aperture used.')
-    parser.add_argument('--sca', type=int, default=7, help='SCA to simulate')
+    parser.add_argument('--sca', type=int, default=7, help='SCA to simulate. Use -1 to generate images for all SCAs.')
     parser.add_argument('--usecrds', action='store_true',
                         help='Use CRDS for distortion map')
     parser.add_argument('--webbpsf', action='store_true',


### PR DESCRIPTION
On main, users can generate images for all SCAs using `romanisim-make-image ... --sca -1 ...`, in a case that gets caught here:
https://github.com/spacetelescope/romanisim/blob/e0e6a979db8b43cbdb22e8082ae14e9ed2f8cd4d/scripts/romanisim-make-image#L27-L37

This feature isn't written about in the docs or in the argument's help notes, so I've added a note to both.