### PR TITLE
Add support for image input

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Contents
    romanisim/refs
 
    romanisim/catalog
+   romanisim/image-input
    romanisim/apt
 
    romanisim/bandpass

--- a/docs/romanisim/image-input.rst
+++ b/docs/romanisim/image-input.rst
@@ -1,7 +1,7 @@
 Image Input
 ===========
 
-The simulator can alternatively take as input a catalog that references a separate list of images of sources.  The format of the catalog is described below, and the underlying "list of images" is described by a ``RealGalaxyCatalog``; see :ref:`Constructing a RealGalaxyCatalog`.  The concept here is that users may have noiseless images of galaxies from, for example, hydro simulations, and may wish to inject those into simulated images at specific locations.  Or users may have reference images from, for example, the COSMOS field, which could be used as truth images for simulations.
+The simulator can alternatively take as input a catalog that references a separate list of images of sources.  The format of the catalog is described below, and the underlying "list of images" is described by a ``RealGalaxyCatalog``; see :ref:`constructing-a-rgc`.  The concept here is that users may have noiseless images of galaxies from, for example, hydro simulations, and may wish to inject those into simulated images at specific locations.  Or users may have reference images from, for example, the COSMOS field, which could be used as truth images for simulations.
 
 The simulator leverages GalSim's ``RealGalaxyCatalog`` framework to support this use case.  There are a handful of existing catalogs of images in the appropriate format for use with the ``RealGalaxyCatalog``---in particular, `GalSim's COSMOS reference catalog <https://galsim-developers.github.io/GalSim/_build/html/real_gal.html#downloading-the-cosmos-catalog>`_ .
 
@@ -42,6 +42,7 @@ Following these required fields is a series of columns giving the fluxes of the 
 
 The simulator then renders these images in the scene and produces the simulated L1 or L2 images.
 
+.. _constructing-a-rgc:
 
 Constructing a RealGalaxyCatalog
 ================================

--- a/docs/romanisim/image-input.rst
+++ b/docs/romanisim/image-input.rst
@@ -1,0 +1,52 @@
+Image Input
+===========
+
+The simulator can alternatively take as input a catalog that references a separate list of images of sources.  The concept here is that users may have noiseless images of galaxies from, for example, hydro simulations, and may wish to inject those into simulated images at specific locations.  Or users may have reference images from, for example, the COSMOS field, which could be used as truth images for simulations.
+
+The simulator leverages GalSim's ``RealGalaxyCatalog`` framework to support this use case.  There are a handful of existing catalogs of images in the appropriate format for use with the ``RealGalaxyCatalog``---in particular, `GalSim's COSMOS reference catalog <https://galsim-developers.github.io/GalSim/_build/html/real_gal.html#downloading-the-cosmos-catalog>`_ .
+
+Using images as input comes with some subtleties.  The input images must have some well-defined PSF, which is specified as part of the reference catalog.  When these images are rendered in the scene, the input PSF is deconvolved before convolution with the Roman PSF.  As long as the input PSF is sharper than the output PSF, this causes no issues, but when the input PSF is larger than the output PSF, this requires deconvolving the input images, which usually produces ringing artifacts.  Care must be taken to provide input images with sharper PSFs than required in the output images to avoid this kind of artifact.
+
+For image input, the simulator takes a catalog with the following structure::
+
+     ra     dec   ident  rotate shear_pa shear_ba  dilate   F062  
+  float64 float64 int64 float64 float64  float64  float64 float64 
+  ------- ------- ----- ------- -------- -------- ------- ------- 
+   269.9    66.0     0    303.2    24.2     0.9      0.3  4.9e-08 
+   270.0    66.0     1    220.8   307.5     0.6      0.1  3.8e-07 
+   269.9    66.1     0    194.0   134.0     0.7      0.4  3.6e-07 
+   269.8    66.0     1    356.9   244.6     0.3      0.1  9.4e-08 
+   269.9    66.1     0     91.0   335.1     0.9      0.1  5.0e-06 
+   269.8    66.0     1     26.6   167.0     0.6      0.4  5.0e-08 
+   269.9    66.0     0    152.3   103.7     0.5      0.3  3.4e-07 
+   269.9    66.1     1    233.8    53.4     0.6      0.3  1.9e-06 
+   269.8    66.0     0     97.8   323.9     0.6      0.2  3.1e-06 
+   269.8    66.1     1     83.4   343.1     0.9      0.1  2.9e-08 
+   269.9    66.0     0    219.1   347.5     0.7      0.0  3.2e-07 
+   269.9    66.1     1     6.91   109.7     0.5      0.4  2.5e-07 
+   269.9    66.0     0    12.04    44.2     0.6      0.1  2.7e-07
+
+Moreover, the table metadata must include the keyword ``real_galaxy_catalog_filename`` specifying the location of the ``RealGalaxyCatalog`` catalog file.  The ``ident`` keyword then specifies the id of the galaxy image to use from the RealGalaxyCatalog, which is rendered at the specified location (ra, dec) and is optionally rotated (rotate), sheared (shear_pa, shear_ba), and dilated (dilate).  Finally, total fluxes in maggies (see the catalog :doc:`docs </romanisim/catalog>`) in specified bandpasses are given.
+
+The following fields must be specified for each source:
+
+* ra: the right ascension of the source
+* dec: the declination of the source
+* ident: the ID of the source image in the RealGalaxyCatalog
+* rotate: the amount to rotate the source relative to its orientation in the RealGalaxyCatalog (degrees)
+* shear_pa: the angle on which to shear the galaxy (i.e., beta `here <https://galsim-developers.github.io/GalSim/_build/html/shear.html#the-shear-class>`_) (degrees)
+* shear_ba: the minor-to-major axis ratio of the shear (i.e., q `here <https://galsim-developers.github.io/GalSim/_build/html/shear.html#the-shear-class>`_)
+* dilate: the amount to dilate (>1) or shrink (<1) the source
+
+Following these required fields is a series of columns giving the fluxes of the the sources in "maggies", as in the catalog :doc:`docs </romanisim/catalog>`_ .
+
+The simulator then renders these images in the scene and produces the simulated L1 or L2 images.
+
+
+Constructing a RealGalaxyCatalog
+================================
+
+The simulator contains a routine intended to make it easier to construct ``RealGalaxyCatalog``s from lists of input images and their associated PSF.  This helper routine does not expose all of the functionality of the ``RealGalaxyCatalog``, but it can at least help get one started.  Given a list of fits files containing images of galaxies and an image of their PSF, the routine builds the index file, image file, and PSF file needed by the image input mode.  One can then specify the index file name in the ``real_galaxy_catalog_filename`` attribute of the catalog and generate sources.
+
+See the ``test_image_input`` `unit test <https://github.com/spacetelescope/romanisim/blob/main/romanisim/tests/test_image.py>`_ for a fully worked example.
+

--- a/docs/romanisim/image-input.rst
+++ b/docs/romanisim/image-input.rst
@@ -1,7 +1,7 @@
 Image Input
 ===========
 
-The simulator can alternatively take as input a catalog that references a separate list of images of sources.  The concept here is that users may have noiseless images of galaxies from, for example, hydro simulations, and may wish to inject those into simulated images at specific locations.  Or users may have reference images from, for example, the COSMOS field, which could be used as truth images for simulations.
+The simulator can alternatively take as input a catalog that references a separate list of images of sources.  The format of the catalog is described below, and the underlying "list of images" is described by a ``RealGalaxyCatalog``; see :ref:`Constructing a RealGalaxyCatalog`.  The concept here is that users may have noiseless images of galaxies from, for example, hydro simulations, and may wish to inject those into simulated images at specific locations.  Or users may have reference images from, for example, the COSMOS field, which could be used as truth images for simulations.
 
 The simulator leverages GalSim's ``RealGalaxyCatalog`` framework to support this use case.  There are a handful of existing catalogs of images in the appropriate format for use with the ``RealGalaxyCatalog``---in particular, `GalSim's COSMOS reference catalog <https://galsim-developers.github.io/GalSim/_build/html/real_gal.html#downloading-the-cosmos-catalog>`_ .
 

--- a/docs/romanisim/image-input.rst
+++ b/docs/romanisim/image-input.rst
@@ -38,7 +38,7 @@ The following fields must be specified for each source:
 * shear_ba: the minor-to-major axis ratio of the shear (i.e., q `here <https://galsim-developers.github.io/GalSim/_build/html/shear.html#the-shear-class>`_)
 * dilate: the amount to dilate (>1) or shrink (<1) the source
 
-Following these required fields is a series of columns giving the fluxes of the the sources in "maggies", as in the catalog :doc:`docs </romanisim/catalog>`_ .
+Following these required fields is a series of columns giving the fluxes of the the sources in "maggies", as in the catalog :doc:`docs </romanisim/catalog>`.
 
 The simulator then renders these images in the scene and produces the simulated L1 or L2 images.
 

--- a/docs/romanisim/image-input.rst
+++ b/docs/romanisim/image-input.rst
@@ -46,7 +46,7 @@ The simulator then renders these images in the scene and produces the simulated 
 Constructing a RealGalaxyCatalog
 ================================
 
-The simulator contains a routine intended to make it easier to construct ``RealGalaxyCatalog``s from lists of input images and their associated PSF.  This helper routine does not expose all of the functionality of the ``RealGalaxyCatalog``, but it can at least help get one started.  Given a list of fits files containing images of galaxies and an image of their PSF, the routine builds the index file, image file, and PSF file needed by the image input mode.  One can then specify the index file name in the ``real_galaxy_catalog_filename`` attribute of the catalog and generate sources.
+The simulator contains a routine intended to make it easier to construct a ``RealGalaxyCatalog`` from lists of input images and their associated PSF.  This helper routine does not expose all of the functionality of the ``RealGalaxyCatalog``, but it can at least help get one started.  Given a list of fits files containing images of galaxies and an image of their PSF, the routine builds the index file, image file, and PSF file needed by the image input mode.  One can then specify the index file name in the ``real_galaxy_catalog_filename`` attribute of the catalog and generate sources.
 
 See the ``test_image_input`` `unit test <https://github.com/spacetelescope/romanisim/blob/main/romanisim/tests/test_image.py>`_ for a fully worked example.
 

--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -415,7 +415,7 @@ def make_image_catalog(image_filenames, psf, out_base_filename,
     fits input images.  These input images can come from anywhere, but are
     expected to come from either real imaging or from hydro simulations.
 
-    This routine assumes that all images a common PSF, which is given as the
+    This routine assumes that all images share a common PSF, which is given as the
     PSF argument.  This PSF is deconvolved before reconvolving with the
     appropriate filter-specific PSF when rendering a Roman image.
 

--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -409,16 +409,15 @@ def make_image_catalog(image_filenames, psf, out_base_filename,
                        pixel_scale=0.05):
     """Construct a RealGalaxyCatalog from a list of image filenames.
 
-    GalSim supports catalogs of real galaxies from images that can be inserted
-    into images.  This function makes it easy to produce a minimal set of files
-    that can be used as a GalSim RealGalaxyCatalog from list list of fits
-    images.  These images can come from anywhere, but are expected to come from
-    either real imaging or hydro simulations.
+    GalSim supports catalogs of real galaxies from input images that can be
+    inserted into output images.  This function makes it easy to produce a
+    set of files that can be used as a GalSim RealGalaxyCatalog from a list of
+    fits input images.  These input images can come from anywhere, but are
+    expected to come from either real imaging or from hydro simulations.
 
-    This routine assumes that all images have a pixel scale of 0.05" and are
-    seen through a common PSF, which is given as the PSF argument.  This PSF is
-    deconvolved before reconvolving with the appropriate filter-specific PSF
-    when rendering a Roman image.
+    This routine assumes that all images a common PSF, which is given as the
+    PSF argument.  This PSF is deconvolved before reconvolving with the
+    appropriate filter-specific PSF when rendering a Roman image.
 
     Files are written to the provided base filename, plus
     ".fits", "_image.fits", and "_psf.fits" extensions.  The first file

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -427,7 +427,7 @@ def test_simulate_counts():
     # argument is high enough!
     roman.n_pix = 100
 
-    meta = util.default_image_meta(optical_element='F158')
+    meta = util.default_image_meta(filter_name='F158')
     wcs.fill_in_parameters(meta, coord)
     im1 = image.simulate_counts(meta, chromcat, usecrds=False,
                                 webbpsf=False, ignore_distant_sources=100)
@@ -457,8 +457,8 @@ def test_simulate():
     coord = SkyCoord(270 * u.deg, 66 * u.deg)
     time = Time('2020-01-01T00:00:00')
     filter_name = 'F158'
-    meta = default_image_meta(time=time, filter_name=filter_name,
-                              coord=coord)
+    meta = util.default_image_meta(time=time, filter_name=filter_name,
+                                   coord=coord)
 
     chromcat = imdict['chromcatalog']
     graycat = imdict['graycatalog']
@@ -851,7 +851,6 @@ def test_image_input(tmpdir):
     catalog.make_image_catalog(filenames, psf, base_rgc_filename)
 
     # make some metadata to describe an image for us to render
-    imdict = set_up_image_rendering_things()
     roman.n_pix = 500
     coord = SkyCoord(270 * u.deg, 66 * u.deg)
     meta = util.default_image_meta(coord=coord, filter_name='F087')

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -840,7 +840,7 @@ def test_image_input(tmpdir):
     psf[cenpix, cenpix] = 1
     from scipy.ndimage import gaussian_filter
     sigma = 1
-    psf = gaussian_filter(psf, 1)
+    psf = gaussian_filter(psf, sigma)
 
     # set up the image catalog
     from astropy.io import fits

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -333,3 +333,51 @@ def sample_king_distances(rc, rt, npts, rng=None):
     cdf /= cdf[-1]
     radii = np.interp(rr, cdf, x)
     return radii
+
+
+def default_image_meta(time=None, ma_table=1, filter_name='F087',
+                       detector='WFI01', coord=None):
+    """Return some simple default metadata for input to image.simulate
+
+    Parameters
+    ----------
+    time : astropy.time.Time
+        Time to use, default to 2020-01-01
+    ma_table : int
+        MA table number to use
+    filter_name : str
+        filter name to use
+    detector : str
+        detector to use
+    coord : astropy.coordinates.SkyCoord
+        coordinates to use, default to (270, 66)
+
+    Returns
+    -------
+    Metadata dictionary corresponding to input parameters.
+    """
+
+    if time is None:
+        time = Time('2020-01-01T00:00:00')
+    if coord is None:
+        coord = SkyCoord(270 * u.deg, 66 * u.deg)
+
+    meta = {
+        'exposure': {
+            'start_time': time,
+            'ma_table_number': 1,
+        },
+        'instrument': {
+            'optical_element': filter_name,
+            'detector': 'WFI01'
+        },
+        'wcsinfo': {
+            'ra_ref': coord.ra.to(u.deg).value,
+            'dec_ref': coord.dec.to(u.deg).value,
+            'v2_ref': 0,
+            'v3_ref': 0,
+            'roll_ref': 0,
+        },
+    }
+
+    return meta


### PR DESCRIPTION
Add support for image input to the simulator.

Conceptually, the idea is that users may have a set of "truth" data as to what real galaxies look like.  This could come from hydro simulations or deep images of galaxies.  These galaxies have better fidelity than the kind of simple parametric galaxies ordinary catalog input supports.

This PR adds a new kind of catalog input mode, where the catalog input includes an 'ident' field that indicates which galaxy in a catalog of galaxy images should be input into an image at a given location.  On top of that, it includes additional fields that specify how that galaxy image should be sheared, dilated, or rotated.  The image is then rendered with the given galaxies at the given locations.

This feature leverages the RealGalaxyCatalog class in GalSim, allowing it to be used in combination with existing true galaxies catalogs in the GalSim format, though only a subset of the GalSim features are presently supported.

A new function `catalog.make_image_catalog` has been added to make it easier to make new catalogs of true images, and this feature is exercised in the unit tests to make some trivial disc and rectangle galaxies.

Caveat emptor: the RealGalaxyCatalog relies on the images to be simulated to have some point spread function.  This point spread function is then deconvolved from the image before the image is convolved with the Roman PSF.  This leads to ringing when the Roman PSF is sharper than the original image PSF---essentially, the simulation is being asked to invent sub-pixel information, and it does not do so well.  This also occurs if the image is dilated significantly before rendering: the dilation means that the same input pixels correspond to more output pixels, and again information must be invented.

This PR implements DMS 228 and adds construction of the corresponding artifacts.