### PR TITLE
Metadata updates for science verification.

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -881,8 +881,9 @@ def make_asdf(slope, slopevar_rn, slopevar_poisson, metadata=None,
         out['meta'].update(metadata)
 
     if imwcs is not None:  # add a WCS
-        out['meta'].update(wcs=wcs.convert_wcs_to_gwcs(imwcs))
-        out['meta']['wcsinfo']['s_region'] = wcs.create_s_region(imwcs)
+        gwcs = wcs.convert_wcs_to_gwcs(imwcs)
+        out['meta'].update(wcs=gwcs)
+        out['meta']['wcsinfo']['s_region'] = wcs.create_s_region(gwcs)
 
     util.update_photom_keywords(out, gain=gain)
 

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -612,6 +612,8 @@ def gather_reference_data(image_mod, usecrds=False):
             for reftype, reffn in reffiles.items():
                 if reftype in ['inverselinearity', 'ipc', 'flat']:
                     continue
+                if reftype not in refsneeded:
+                    continue
                 image_mod.meta.ref_file[reftype] = os.path.basename(reffn)
         if flatneeded:
             try:

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -5,28 +5,19 @@ for most of the real work.
 """
 
 import time
+import os
 import copy
 import numpy as np
 import astropy.time
-from astropy import units as u
-from astropy import coordinates
-from astropy import table
+from astropy import units as u, coordinates, table
 import asdf
 import galsim
 from galsim import roman
-
-
-from . import wcs
-from . import catalog
-from . import parameters
-from . import util
-from . import nonlinearity
-from . import ramp
+from . import wcs, catalog, parameters, util, nonlinearity, ramp, log
 import romanisim.l1
 import romanisim.bandpass
 import romanisim.psf
 import romanisim.persistence
-from romanisim import log
 
 import roman_datamodels
 import roman_datamodels.maker_utils as maker_utils
@@ -605,6 +596,7 @@ def gather_reference_data(image_mod, usecrds=False):
     """
 
     reffiles = {k: v for k, v in parameters.reference_data.items()}
+    reffiles.pop('photom')
 
     out = dict(**reffiles)
     if usecrds:
@@ -617,6 +609,10 @@ def gather_reference_data(image_mod, usecrds=False):
             reffiles.update(crds.getreferences(
                 image_mod.get_crds_parameters(), reftypes=refsneeded,
                 observatory='roman'))
+            for reftype, reffn in reffiles.items():
+                if reftype in ['inverselinearity', 'ipc', 'flat']:
+                    continue
+                image_mod.meta.ref_file[reftype] = os.path.basename(reffn)
         if flatneeded:
             try:
                 flatfile = crds.getreferences(
@@ -625,6 +621,7 @@ def gather_reference_data(image_mod, usecrds=False):
 
                 flat_model = roman_datamodels.datamodels.FlatRefModel(flatfile)
                 flat = flat_model.data[...].copy()
+                image_mod.meta.ref_file['flat'] = os.path.basename(flatfile)
             except crds.core.exceptions.CrdsLookupError:
                 log.warning('Could not find flat; using 1')
                 flat = 1
@@ -808,7 +805,7 @@ def simulate(metadata, objlist,
         l2dq = np.bitwise_or.reduce(l1dq, axis=0)
         im, extras = make_asdf(
             *slopeinfo, metadata=image_mod.meta, persistence=persistence,
-            dq=l2dq, imwcs=counts.wcs)
+            dq=l2dq, imwcs=counts.wcs, gain=gain)
     else:
         extras = dict()
 
@@ -849,18 +846,15 @@ def make_test_catalog_and_images(
 
 
 def make_asdf(slope, slopevar_rn, slopevar_poisson, metadata=None,
-              filepath=None, persistence=None, dq=None, imwcs=None):
+              filepath=None, persistence=None, dq=None, imwcs=None,
+              gain=None):
     """Wrap a galsim simulated image with ASDF/roman_datamodel metadata.
 
     Eventually this needs to get enough info to reconstruct a refit WCS.
     """
 
-    out = maker_utils.mk_level2_image()
-    # fill this output with as much real information as possible.
-    # aperture['name'] gets the correct SCA
-    # aperture['position_angle'] gets the correct PA
-    # cal['step'] is left empty for now, but in principle
-    #     could be filled out at some level
+    out = maker_utils.mk_level2_image(
+        n_groups=len(metadata['exposure']['read_pattern']))
     # ephemeris contains a lot of angles that could be computed.
     # exposure contains
     #     ngroups, nframes, sca_number, gain_factor, integration_time,
@@ -881,23 +875,16 @@ def make_asdf(slope, slopevar_rn, slopevar_poisson, metadata=None,
     #     the earth out to L2, and use that for the velocity
     #     aberration?  Don't do until someone asks.
     # visit: start_time, end_time, total_exposures, ...?
-    # wcsinfo: v2_ref, v3_ref, vparitiy, v3yangle, ra_ref, dec_ref
+    # wcsinfo: v2_ref, v3_ref, vparity, v3yangle, ra_ref, dec_ref
     #     roll_ref, s_region
-    # photometry: all of these conversions could be filled out
-    #     just requires the assumed zero point, some definitions,
-    #     and the WCS.
-    # border_ref_pix_left, _right, _top, _bottom:
-    #     leave reference blank for now
-    # dq_border_pix_left, _right, _top, _bottom:
-    #     leave border pixels blank for now.
-    # amp33: leave blank for now.
-    # data: image
-    # var_flat: currently zero
     if metadata is not None:
         out['meta'].update(metadata)
 
     if imwcs is not None:  # add a WCS
         out['meta'].update(wcs=wcs.convert_wcs_to_gwcs(imwcs))
+        out['meta']['wcsinfo']['s_region'] = wcs.create_s_region(imwcs)
+
+    util.update_photom_keywords(out, gain=gain)
 
     out['data'] = slope
     out['dq'] = np.zeros(slope.shape, dtype='u4')

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -418,10 +418,7 @@ def make_asdf(resultants, dq=None, filepath=None, metadata=None, persistence=Non
         including DQ images and persistence information.
     """
 
-    try:
-        import roman_datamodels.testing.utils as maker_utils
-    except ImportError:
-        import roman_datamodels.maker_utils as maker_utils
+    import roman_datamodels.maker_utils as maker_utils
     nborder = parameters.nborder
     npix = galsim.roman.n_pix + 2 * nborder
     out = maker_utils.mk_level1_science_raw(

--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -167,3 +167,6 @@ persistence = {
     "half_well": 50000,
     "ignorerate": 0.01
 }
+
+# angle of V3 relative to +Y
+V3IdlYAngle = -60

--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -16,6 +16,7 @@ import roman_datamodels
 from roman_datamodels import stnode
 from romanisim import catalog, image, wcs
 from romanisim import parameters, log
+import romanisim
 
 NMAP = {'apt':'{http://www.stsci.edu/Roman/APT}'}
 
@@ -250,6 +251,7 @@ def simulate_image_file(args, metadata, cat, rng=None, persist=None):
     if 'filename' in romanisimdict:
         romanisimdict['filename'] = str(romanisimdict['filename'])
     romanisimdict.update(**extras)
+    romanisimdict['version'] = romanisim.__version__
 
     basename = os.path.basename(args.filename)
     obsdata = parse_filename(basename)
@@ -263,6 +265,8 @@ def simulate_image_file(args, metadata, cat, rng=None, persist=None):
             'WFI_' + args.pretend_spectral.upper())
         im['meta']['instrument']['optical_element'] = (
             args.pretend_spectral.upper())
+        im['meta']['guidestar']['gw_window_xsize'] = 170
+        im['meta']['guidestar']['gw_window_ysize'] = 24
 
     drop_extra_dq = getattr(args, 'drop_extra_dq', False)
     if drop_extra_dq and ('dq' in romanisimdict):

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -518,27 +518,28 @@ def update_photom_keywords(im, gain=None):
     gain = (np.median(gain)
             if gain is not None else parameters.reference_data['gain'])
     gain = gain.value if isinstance(gain, u.Quantity) else gain
-    if 'wcs' in out['meta']:
-        wcs = out['meta']['wcs']
+    if 'wcs' in im['meta']:
+        wcs = im['meta']['wcs']
         cenpix = (im.data.shape[0] // 2, im.data.shape[1] // 2)
-        cc = wcs.world_to_pix((cenpix[0], cenpix[0], cenpix[0] + 1),
-                              (cenpix[1], cenpix[1] + 1, cenpix[1]))
+        cc = wcs.pixel_to_world((cenpix[0], cenpix[0], cenpix[0] + 1),
+                                (cenpix[1], cenpix[1] + 1, cenpix[1]))
         angle = (cc[0].position_angle(cc[1]) -
                  cc[0].position_angle(cc[2]))
         area = (cc[0].separation(cc[1]) * cc[0].separation(cc[2])
                 * np.sin(angle.to(u.rad).value))
-        out['meta']['photometry']['pixelarea_steradians'] = area.to(u.sr)
-        out['meta']['photometry']['pixelarea_arcsecsq'] = (
+        im['meta']['photometry']['pixelarea_steradians'] = area.to(u.sr)
+        im['meta']['photometry']['pixelarea_arcsecsq'] = (
             area.to(u.arcsec ** 2))
-        out['meta']['conversion_megajansky'] = gain * (
+        im['meta']['photometry']['conversion_megajanskys'] = gain * (
             3631 /
             bandpass.get_abflux(im.meta['instrument']['optical_element']) /
             10 ** 6 /
-            out['meta']['photometry']['pixelarea_steradians']) * u.MJy / u.sr
-        out['meta']['conversion_microjansky'] = (
-            out['meta']['conversion_megajansky'].to(u.uJy / u.arcsec ** 2))
+            im['meta']['photometry']['pixelarea_steradians']) * u.MJy
+        im['meta']['photometry']['conversion_microjanskys'] = (
+            im['meta']['photometry']['conversion_megajanskys'].to(
+                u.uJy / u.arcsec ** 2))
 
-    out['meta']['photometry']['conversion_megajansky_uncertainty'] = (
+    im['meta']['photometry']['conversion_megajanskys_uncertainty'] = (
         0 * u.MJy / u.sr)
-    out['meta']['photometry']['conversion_microjansky_uncertainty'] = (
+    im['meta']['photometry']['conversion_microjanskys_uncertainty'] = (
         0 * u.uJy / u.arcsec ** 2)

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -6,8 +6,9 @@ from astropy.coordinates import SkyCoord
 from astropy import units as u
 from astropy.time import Time
 import galsim
+import gwcs as gwcsmod
 
-from romanisim import parameters, wcs
+from romanisim import parameters, wcs, bandpass
 from scipy import integrate
 
 
@@ -186,6 +187,8 @@ def add_more_metadata(metadata):
 
     if 'exposure' not in metadata.keys():
         metadata['exposure'] = {}
+    if 'guidestar' not in metadata.keys():
+        metadata['guidestar'] = {}
     read_pattern = metadata['exposure'].get(
         'read_pattern',
         parameters.read_pattern[metadata['exposure']['ma_table_number']])
@@ -214,6 +217,12 @@ def add_more_metadata(metadata):
     metadata['exposure']['exposure_time'] = openshuttertime
     metadata['exposure']['effective_exposure_time'] = openshuttertime
     metadata['exposure']['duration'] = openshuttertime
+    metadata['guidestar']['gw_window_xsize'] = 16
+    metadata['guidestar']['gw_window_ysize'] = 16
+    metadata['guidestar']['gw_window_xstop'] = (
+        metadata['guidestar']['gw_window_xstart'])
+    metadata['guidestar']['gw_window_ystop'] = (
+        metadata['guidestar']['gw_window_ystart'])
     # integration_start?  integration_end?  nints = 1?  ...
 
     if 'target' not in metadata.keys():
@@ -268,10 +277,12 @@ def update_aperture_and_wcsinfo_metadata(metadata, gwcs):
     gwcs : WCS object
         image WCS
     """
-    if ('aperture' not in metadata or 'wcsinfo' not in metadata
-            or not isinstance(gwcs, wcs.GWCS)):
+    if 'aperture' not in metadata or 'wcsinfo' not in metadata:
         return
-    gwcs = gwcs.wcs
+    if isinstance(gwcs, wcs.GWCS):
+        gwcs = gwcs.wcs
+    if not isinstance(gwcs, gwcsmod.wcs.WCS):
+        return
     metadata['aperture']['name'] = (
         metadata['instrument']['detector'][:3] + '_'
         + metadata['instrument']['detector'][3:] + '_FULL')
@@ -279,10 +290,26 @@ def update_aperture_and_wcsinfo_metadata(metadata, gwcs):
     center = (galsim.roman.n_pix / 2 - 0.5, galsim.roman.n_pix / 2 - 0.5)
     v2v3 = distortion(*center)
     radec = gwcs(*center)
+    t2sky = gwcs.get_transform('v2v3', 'world')
+    radecn = t2sky(v2v3[0], v2v3[1] + 1)
+    roll_ref = (
+        SkyCoord(radec[0] * u.deg, radec[1] * u.deg).position_angle(
+        SkyCoord(radecn[0] * u.deg, radecn[1] * u.deg)))
+    roll_ref = roll_ref.to(u.deg).value
+    # new roll ref appropriate for new v2v3 ref
+    # note: some of this logic will need to change after
+    # aberration is incorporated.  roll_ref will need to
+    # be computed from the aberrated v2v3 frame to the sky.
+    # but maybe this doesn't matter since the aberrated v2v3
+    # axes are parallel to the v2v3 axes.
+    # whether we need to change radec ref, v2v3 ref depends
+    # on how we ultimately define these quantities.
+
     metadata['wcsinfo']['ra_ref'] = radec[0]
     metadata['wcsinfo']['dec_ref'] = radec[1]
     metadata['wcsinfo']['v2_ref'] = v2v3[0]
     metadata['wcsinfo']['v3_ref'] = v2v3[1]
+    metadata['wcsinfo']['roll_ref'] = roll_ref
 
 
 def king_profile(r, rc, rt):
@@ -465,3 +492,53 @@ def default_image_meta(time=None, ma_table=1, filter_name='F087',
     }
 
     return meta
+
+
+def update_photom_keywords(im, gain=None):
+    """Add photometry calibration keywords to image metadata.
+
+    This fills out the im.meta['photometry'] keywords:
+
+    * conversion_megajanskys (MJy/sr corresponding to 1 DN / s / pix)
+    * conversion_microjanskys (uJy/sq. arcsec corresponding to 1 DN / s / pix)
+    * corresponding uncertainties (0 in appropriate units)
+    * pixelarea_steradians (area of central pixel in steradians)
+    * pixelarea_arcsecsq (area of central pixel in square arcseconds)
+
+    The values are derived from the bandpasses of the filters and and the WCS
+    of the image.
+
+    Parameters
+    ----------
+    im : roman_datamodels.ImageModel
+        Image whose metadata should be updated with photometry keywords
+    gain : float, Quantity, array
+        Gain image to use
+    """
+    gain = (np.median(gain)
+            if gain is not None else parameters.reference_data['gain'])
+    gain = gain.value if isinstance(gain, u.Quantity) else gain
+    if 'wcs' in out['meta']:
+        wcs = out['meta']['wcs']
+        cenpix = (im.data.shape[0] // 2, im.data.shape[1] // 2)
+        cc = wcs.world_to_pix((cenpix[0], cenpix[0], cenpix[0] + 1),
+                              (cenpix[1], cenpix[1] + 1, cenpix[1]))
+        angle = (cc[0].position_angle(cc[1]) -
+                 cc[0].position_angle(cc[2]))
+        area = (cc[0].separation(cc[1]) * cc[0].separation(cc[2])
+                * np.sin(angle.to(u.rad).value))
+        out['meta']['photometry']['pixelarea_steradians'] = area.to(u.sr)
+        out['meta']['photometry']['pixelarea_arcsecsq'] = (
+            area.to(u.arcsec ** 2))
+        out['meta']['conversion_megajansky'] = gain * (
+            3631 /
+            bandpass.get_abflux(im.meta['instrument']['optical_element']) /
+            10 ** 6 /
+            out['meta']['photometry']['pixelarea_steradians']) * u.MJy / u.sr
+        out['meta']['conversion_microjansky'] = (
+            out['meta']['conversion_megajansky'].to(u.uJy / u.arcsec ** 2))
+
+    out['meta']['photometry']['conversion_megajansky_uncertainty'] = (
+        0 * u.MJy / u.sr)
+    out['meta']['photometry']['conversion_microjansky_uncertainty'] = (
+        0 * u.uJy / u.arcsec ** 2)

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -219,10 +219,11 @@ def add_more_metadata(metadata):
     metadata['exposure']['duration'] = openshuttertime
     metadata['guidestar']['gw_window_xsize'] = 16
     metadata['guidestar']['gw_window_ysize'] = 16
-    metadata['guidestar']['gw_window_xstop'] = (
-        metadata['guidestar']['gw_window_xstart'])
-    metadata['guidestar']['gw_window_ystop'] = (
-        metadata['guidestar']['gw_window_ystart'])
+    if 'gw_window_xstart' in metadata['guidestar']:
+        metadata['guidestar']['gw_window_xstop'] = (
+            metadata['guidestar']['gw_window_xstart'])
+        metadata['guidestar']['gw_window_ystop'] = (
+            metadata['guidestar']['gw_window_ystart'])
     # integration_start?  integration_end?  nints = 1?  ...
 
     if 'target' not in metadata.keys():
@@ -255,7 +256,7 @@ def add_more_metadata(metadata):
     if 'ephemeris' in metadata:
         metadata['ephemeris']['ephemeris_reference_frame'] = (
             metadata['ephemeris']['ephemeris_reference_frame'][:10])
-    if 'guidestar' in metadata:
+    if 'guidestar' in metadata and 'gs_epoch' in metadata['guidestar']:
         metadata['guidestar']['gs_epoch'] = (
             metadata['guidestar']['gs_epoch'][:10])
 

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -481,11 +481,11 @@ def create_s_region(wcs, shape=None):
     if shape is not None:
         bbox = ((-0.5, shape[-1] - 0.5), (-0.5, shape[-2] - 0.5))
     else:
-        bbox = wcs.bounding_box
-    bbox = ((int(round(x + 0.5)) for x in r) for r in bbox)
+        bbox = [[x for x in r] for r in wcs.bounding_box]
+    bbox = [[int(round(r[0] + 0.5)), int(round(r[1] - 0.5))] for r in bbox]
     xcorn, ycorn = ([bbox[0][0], bbox[0][1], bbox[0][1], bbox[0][0]],
                     [bbox[1][0], bbox[1][0], bbox[1][1], bbox[1][1]])
     racorn, deccorn = wcs(xcorn, ycorn)
-    rd = np.array([[r, d] for r, d in zip(racorn, decorn)])
+    rd = np.array([[r, d] for r, d in zip(racorn, deccorn)])
     s_region = "POLYGON ICRS " + " ".join([str(x) for x in rd.ravel()])
     return s_region

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -16,6 +16,7 @@ boresight for galsim.roman than for what I get from CRDS.  This bears
 more investigation.
 """
 
+import os
 import warnings
 import math
 import numpy as np
@@ -30,13 +31,8 @@ import gwcs.wcs
 import galsim.wcs
 from galsim import roman
 from . import util
-
-
-# Needed until RCAL release unfreezing link to RDM/RAD versions 0.14.1
-try:
-    import roman_datamodels.maker_utils as maker_utils
-except ImportError:
-    import roman_datamodels.testing.utils as maker_utils
+import romanisim.parameters
+import roman_datamodels.maker_utils as maker_utils
 
 
 def fill_in_parameters(parameters, coord, pa_aper=0, boresight=True):
@@ -78,8 +74,8 @@ def fill_in_parameters(parameters, coord, pa_aper=0, boresight=True):
         parameters['pointing']['dec_v1'])
 
     # Romanisim uses ROLL_REF = PA_APER - V3IdlYAngle
-    V3IdlYAngle = -60  # this value should eventually be taken from the SIAF
-    parameters['wcsinfo']['roll_ref'] = pa_aper - V3IdlYAngle
+    parameters['wcsinfo']['roll_ref'] = (
+        pa_aper - romanisim.parameters.V3IdlYAngle)
 
     if boresight:
         parameters['wcsinfo']['v2_ref'] = 0
@@ -140,6 +136,7 @@ def get_wcs(image, usecrds=True, distortion=None):
             reftypes=['distortion'],
             observatory='roman',
         )['distortion']
+        image_mod.meta.ref_file['distortion'] = os.path.basename(dist_name)
 
         dist_model = roman_datamodels.datamodels.DistortionRefModel(dist_name)
         distortion = dist_model.coordinate_distortion_transform
@@ -462,3 +459,33 @@ def get_mosaic_wcs(mosaic, shape=None):
                         util.celestialcoord(world_pos))
 
     return wcs
+
+
+def create_s_region(wcs, shape=None):
+    """Create s_region string from wcs.
+
+    Parameters
+    ----------
+    wcs : gwcs.wcs.WCS instance
+        wcs for which s_region is desired
+    shape : tuple
+        use this shape to determine the pixel boundaries instead bounding box
+
+    Returns
+    -------
+    s_region : str
+        the s_region string, POLYGON ICRS + coordinates of 4 corners
+    """
+    if not isinstance(wcs, gwcs.wcs.WCS):
+        raise ValueError('wcs must be a gwcs WCS object.')
+    if shape is not None:
+        bbox = ((-0.5, shape[-1] - 0.5), (-0.5, shape[-2] - 0.5))
+    else:
+        bbox = wcs.bounding_box
+    bbox = ((int(round(x + 0.5)) for x in r) for r in bbox)
+    xcorn, ycorn = ([bbox[0][0], bbox[0][1], bbox[0][1], bbox[0][0]],
+                    [bbox[1][0], bbox[1][0], bbox[1][1], bbox[1][1]])
+    racorn, deccorn = wcs(xcorn, ycorn)
+    rd = np.array([[r, d] for r, d in zip(racorn, decorn)])
+    s_region = "POLYGON ICRS " + " ".join([str(x) for x in rd.ravel()])
+    return s_region


### PR DESCRIPTION
This PR makes a number of metadata changes for science verification.  The pixels are not affected.  It is intended to address #136 .  

Some of the changes:
- There is now a "version" keyword in the 'romanisim' section of the output:
```
>>> asdf.open('l1.asdf')['romanisim']['version']
'0.5.3.dev9+g273099b'
```
- guide window metadata is set to size 16
```
>>> asdf.open('l1.asdf')['roman']['meta']['guidestar']['gw_window_xsize']
16
>>> asdf.open('l1.asdf')['roman']['meta']['guidestar']['gw_window_ysize']
16
```
- photometry metadata is now -999999 for L1 files but has sensible values for L2 files.
```
>>> asdf.open('l2.asdf')['roman']['meta']['photometry']
{'conversion_microjanskys': <Quantity 15.11015947 uJy / arcsec2>, 'conversion_megajanskys': <Quantity 0.64286431 MJy / sr>, 'pixelarea_steradians': <Quantity 2.80827472e-13 sr>, 'pixelarea_arcsecsq': <Quantity 0.01194785 arcsec2>, 'conversion_megajanskys_uncertainty': <Quantity 0. MJy / sr>, 'conversion_microjanskys_uncertainty': <Quantity 0. uJy / arcsec2>}
```
Note these values will not match the romancal versions in detail; they use the bandpass we get from Goddard rather than the CRDS numbers.  Those have a 3% difference (plus a ~factor of two gain difference, since the CRDS versions are for e/s instead of DN/s).
- The ref files get populated in the L1 and L2 files:
```
>>> asdf.open('l2.asdf')['roman']['meta']['ref_file']
{'crds': {'context_used': 'roman_0063.pmap', 'sw_version': '11.17.19'}, 'dark': 'roman_wfi_dark_0896.asdf', 'distortion': 'roman_wfi_distortion_0064.asdf', 'flat': 'roman_wfi_flat_0200.asdf', 'gain': 'roman_wfi_gain_0186.asdf', 'linearity': 'roman_wfi_linearity_0314.asdf', 'mask': 'N/A', 'photom': 'N/A', 'readnoise': 'roman_wfi_readnoise_0748.asdf', 'saturation': 'roman_wfi_saturation_0218.asdf'}
```
I have left the photom one blank since it is not used.
- The WCS for romanisim cannot really be wrong relative to romancal, since defines the wcs used to do the simulation.  The romancal ELP WCS gets run through tweakreg and updated based on an attempt to match detected stars with real stars; romanisim doesn't attempt to simulate this and just outputs the WCS it uses.  I don't think any changes here make sense.  I did however update the roll_ref used for the wcsinfo as part of this PR to use the angles relative to north at the reference points rather than at WFI_CEN.
- I added s_region.  I am not able to find a definition for this quantity.  I am using the coordinates of the centers of the corner pixels.  I picked a different pixel order than romancal, and am using the centers of the corner pixels, while romancal (and likely Webb?) are using the centers of the zeroth row and column of pixels, but the centers of a virtual one-past-the-edge pixel.  This gives the s_region the same physical size as the device would have on the sky, but shifted by half a pixel relative to its boundaries, while the convention I'm using is a pixel smaller but is correctly centered.  If you have opinions about the exact convention for s_region, please advise.
```
>>> asdf.open('l2.asdf')['roman']['meta']['wcsinfo']['s_region']
'POLYGON ICRS 269.98690833079274 65.97427994844489 269.6801513833561 65.97435689705982 269.67682107205064 66.09718041146162 269.9867021551381 66.09721332657264'
```
- I have updated the shapes of the empty, unused border pixel arrays in the L2 product to match expectations from read_pattern.
- I have not addressed changing the L2 metadata to reflect future.  That is beyond the scope of romanisim science validation.