### PR TITLE
Add utilities to automatically download external data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,7 @@ jobs:
     with:
       envs: |
         - linux: check-style
-  latest_data_cache:
-    uses: ./.github/workflows/retrieve_cache.yml
-    with:
-      cache_path: /tmp/data
   test:
-    needs: [ latest_data_cache ]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@924441154cf3053034c6513d5e06c69d262fb9a6  # v1.13.0
     with:
       libraries: |
@@ -38,11 +33,8 @@ jobs:
           - eigen
           - fftw
       setenv: |
-        WEBBPSF_PATH: ${{ needs.latest_data_cache.outputs.cache_path }}/webbpsf-data/
-        GALSIM_CAT_PATH: ${{ needs.latest_data_cache.outputs.cache_path }}/galsim_data/real_galaxy_catalog_23.5_example.fits
         FFTW_DIR: /opt/homebrew/opt/fftw/lib/
-      cache-path: ${{ needs.latest_data_cache.outputs.cache_path }}
-      cache-key: ${{ needs.latest_data_cache.outputs.cache_key }}
+
       envs: |
         - linux: py310-oldestdeps-cov-xdist
         - linux: py310-xdist

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/api/
 
 # PyBuilder
 .pybuilder/

--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -21,6 +21,12 @@ from .bandpass import galsim2roman_bandpass, roman2galsim_bandpass
 from .util import import_webbpsf
 from romanisim import log
 
+__all__ = [
+    "make_one_psf",
+    "make_psf",
+    "VariablePSF",
+]
+
 
 def make_one_psf(sca, filter_name, wcs=None, webbpsf=True, pix=None,
                  chromatic=False, oversample=4, extra_convolution=None, **kw):

--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -18,6 +18,7 @@ import numpy as np
 import galsim
 from galsim import roman
 from .bandpass import galsim2roman_bandpass, roman2galsim_bandpass
+from .util import import_webbpsf
 from romanisim import log
 
 
@@ -75,7 +76,7 @@ def make_one_psf(sca, filter_name, wcs=None, webbpsf=True, pix=None,
     if chromatic:
         log.warning('romanisim does not yet support chromatic PSFs '
                     'with webbpsf')
-    import webbpsf as wpsf
+    wpsf = import_webbpsf()
     filter_name = galsim2roman_bandpass[filter_name]
     wfi = wpsf.WFI()
     wfi.detector = f'SCA{sca:02d}'

--- a/romanisim/tests/test_catalog.py
+++ b/romanisim/tests/test_catalog.py
@@ -6,6 +6,7 @@ import os
 import numpy as np
 import galsim
 from romanisim import catalog
+from romanisim.util import get_galsim_data_path
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 from romanisim import log
@@ -16,7 +17,7 @@ def test_make_dummy_catalog():
     cen = SkyCoord(ra=5 * u.deg, dec=-10 * u.deg)
     radius = 0.2
     nobj = 100
-    fn = os.environ.get('GALSIM_CAT_PATH', None)
+    fn = get_galsim_data_path()
     if fn is not None:
         fn = str(fn)
     cat = catalog.make_dummy_catalog(

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -27,7 +27,7 @@ import asdf
 from astropy.modeling.functional_models import Sersic2D
 import pytest
 from romanisim import log
-from romanisim.util import import_webbpsf
+from romanisim.util import import_webbpsf, get_galsim_data_path
 from roman_datamodels.stnode import WfiScienceRaw, WfiImage
 import romanisim.bandpass
 
@@ -575,7 +575,7 @@ def test_make_test_catalog_and_images():
     # public interface, and may be removed.  We'll settle for just
     # testing that it runs.
     roman.n_pix = 100
-    fn = os.environ.get('GALSIM_CAT_PATH', None)
+    fn = get_galsim_data_path()
     if fn is not None:
         fn = str(fn)
     res = image.make_test_catalog_and_images(usecrds=False,

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -24,12 +24,14 @@ from astropy import units as u
 from astropy.time import Time
 from astropy import table
 import asdf
-import webbpsf
 from astropy.modeling.functional_models import Sersic2D
 import pytest
 from romanisim import log
+from romanisim.util import import_webbpsf
 from roman_datamodels.stnode import WfiScienceRaw, WfiImage
 import romanisim.bandpass
+
+webbpsf = import_webbpsf()
 
 
 def test_in_bounds():

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -18,6 +18,26 @@ from romanisim import parameters, wcs, bandpass
 from scipy import integrate
 
 
+__all__ = [
+    "skycoord",
+    "celestialcoord",
+    "scalergb",
+    "random_points_in_cap",
+    "random_points_in_king",
+    "random_points_at_radii",
+    "add_more_metadata",
+    "update_pointing_and_wcsinfo_metadata",
+    "king_profile",
+    "sample_king_distances",
+    "decode_context_times",
+    "default_image_meta",
+    "update_photom_keywords",
+    "merge_dicts",
+    "import_webbpsf",
+    "get_galsim_data_path",
+]
+
+
 def skycoord(celestial):
     """Turn a CelestialCoord into a SkyCoord.
 

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -590,3 +590,23 @@ def import_webbpsf():
 
     return webbpsf
 
+
+def get_galsim_data_path():
+    path = os.environ.get("GALSIM_CAT_PATH") or Path.home() / "data" / "galsim-data"
+    path.mkdir(parents=True, exist_ok=True)
+    os.environ["GALSIM_CAT_PATH"] = str(path)
+
+    url = "https://github.com/GalSim-developers/GalSim/raw/releases/2.4/examples/data/"
+
+    data_files = (
+        "real_galaxy_catalog_23.5_example.fits",
+        "real_galaxy_catalog_23.5_example_selection.fits",
+        "real_galaxy_catalog_23.5_example_fits.fits",
+    )
+
+    for filename in data_files:
+        if not (path / filename).exists():
+            warnings.warn(f"Downloading {filename}...")
+            urlretrieve(url + filename, path / filename)
+
+    return path / data_files[0]


### PR DESCRIPTION
`webbpsf` and the `galsim` catalog data have to be downloaded independently of installing `romanisim[test]`. These however are required for the tests. I find this rather annoying so, this PR contrives some utilities that download the data if it hasn't been already.