### PR TITLE
Remove python 3.10 tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,7 @@ jobs:
       cache-path: ${{ needs.latest_data_cache.outputs.cache_path }}
       cache-key: ${{ needs.latest_data_cache.outputs.cache_key }}
       envs: |
-        - linux: py310-oldestdeps-cov-xdist
-        - linux: py310-xdist
+        - linux: py311-oldestdeps-cov-xdist
         - linux: py311-xdist
         - linux: py3-xdist
         - macos: py3-xdist

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -31,6 +31,5 @@ jobs:
       cache-path: ${{ needs.latest_data_cache.outputs.cache_path }}
       cache-key: ${{ needs.latest_data_cache.outputs.cache_key }}
       envs: |
-        - macos: py310-xdist
         - macos: py311-xdist
         - linux: py3-devdeps-xdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "romanisim"
 description = "Nancy Grace Roman Space Telescope WFI Simulator"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "STScI", email = "help@stsci.edu" },
 ]
@@ -14,7 +14,7 @@ classifiers = [
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     "asdf >=3.3.0",


### PR DESCRIPTION
This removes the python 3.10 tests since support was removed in roman_datamodels.

@stscieisenhamer , let's see if this fixes the build issues.  I also hadn't appreciated that this leaves a pointer to your branch in pyproject.toml; has that been merged yet?  What happens if romanisim is linked to the released version rather than your special roman_datamodels?