### PR TITLE
Handle cases where more than 2 billion photons enter a pixel.

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -470,7 +470,7 @@ def simulate_counts_generic(image, exptime, objlist=None, psf=None,
         rng_numpy_seed = rng.raw()
         rng_numpy = np.random.default_rng(rng_numpy_seed)
         image.array[:, :] = rng_numpy.binomial(
-            image.array.astype('i4'), flat / maxflat)
+            np.clip(image.array, 0, 2**31 - 1).astype('i4'), flat / maxflat)
 
     if dark is not None:
         workim = image * 0


### PR DESCRIPTION
When more than 2 billion photons are modeled as entering a pixel, the current code trips and dies.  This caps the number of photons entering a pixel to 2**31 - 1.