### PR TITLE
Drop unused dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ docs = [
 test = [
     "ci-watson >=0.3.0",
     "colorama >=0.4.1",
-    "getch >=1.0.0",
     "pytest >=4.6.0, <=8.0",
     "pytest-openfiles >=0.5.0",
     "pytest-doctestplus >=0.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ docs = [
 ]
 test = [
     "ci-watson >=0.3.0",
-    "colorama >=0.4.1",
     "pytest >=4.6.0, <=8.0",
     "pytest-openfiles >=0.5.0",
     "pytest-doctestplus >=0.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ test = [
     "pytest-openfiles >=0.5.0",
     "pytest-doctestplus >=0.10.0",
     "pytest-cov >=2.9.0",
-    "flake8 >=3.6.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
An attempted regtest run with python 3.13 showed a failure when the test machine failed to build `getch`:
https://github.com/spacetelescope/RegressionTests/actions/runs/12264011982/job/34217036983?pr=183#step:14:38
I don't see any uses of this package. (FWIW The python 3.13 tests aren't failing in the CI here so the above failure could be seen as a bug in the proposed regtest test machine changes).

This PR removes unused dependencies:
- getch: looks like a dead package (no release since 2013): https://pypi.org/project/getch/
- colorama: this isn't imported
- flake8: this was replaced by ruff