### PR TITLE
Update wcs interface to use pixel_to_world_values instead of non-values versions.

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -964,8 +964,8 @@ def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, rng=None,
         rng = galsim.UniformDeviate(123)
 
     if x is None or y is None:
-        x, y = model.meta.wcs.numerical_inverse(cat['ra'], cat['dec'],
-                                                with_bounding_box=False)
+        x, y = model.meta.wcs.numerical_inverse(
+            cat['ra'].value, cat['dec'].value, with_bounding_box=False)
 
     filter_name = model.meta.instrument.optical_element
     cat = catalog.table_to_catalog(cat, [filter_name])

--- a/romanisim/l3.py
+++ b/romanisim/l3.py
@@ -740,8 +740,8 @@ def add_more_metadata(metadata, efftimes, filter_name, wcs, shape, nexposures):
     metadata['photometry']['conversion_megajanskys'] = 1
 
     cenx, ceny = ((shape[1] - 1) / 2, (shape[0] - 1) / 2)
-    c1 = wcs.pixel_to_world(cenx, ceny)
-    c2 = wcs.pixel_to_world(cenx + 1, ceny)
+    c1 = wcs.pixel_to_world_values(cenx, ceny)
+    c2 = wcs.pixel_to_world_values(cenx + 1, ceny)
     pscale = c1.separation(c2)
 
     metadata['photometry']['pixelarea_steradians'] = (pscale ** 2).to(u.sr)
@@ -756,7 +756,7 @@ def add_more_metadata(metadata, efftimes, filter_name, wcs, shape, nexposures):
     metadata['resample']['pointings'] = nexposures
     metadata['resample']['product_exposure_time'] = (
         metadata['basic']['max_exposure_time'])
-    xref, yref = wcs.world_to_pixel(
+    xref, yref = wcs.world_to_pixel_values(
         metadata['wcsinfo']['ra_ref'], metadata['wcsinfo']['dec_ref'])
     metadata['wcsinfo']['x_ref'] = xref
     metadata['wcsinfo']['y_ref'] = yref
@@ -769,7 +769,7 @@ def add_more_metadata(metadata, efftimes, filter_name, wcs, shape, nexposures):
     metadata['wcsinfo']['dec_center'] = c1.dec.to(u.degree).value
     xcorn, ycorn = [[0, shape[1] - 1, shape[1] - 1, 0],
                     [0, 0, shape[0] - 1, shape[0] - 1]]
-    ccorn = wcs.pixel_to_world(xcorn, ycorn)
+    ccorn = wcs.pixel_to_world_values(xcorn, ycorn)
     for i, corn in enumerate(ccorn):
         metadata['wcsinfo']['ra_corn{i+1}'] = corn.ra.to(u.degree).value
         metadata['wcsinfo']['dec_corn{i+1}'] = corn.dec.to(u.degree).value

--- a/romanisim/l3.py
+++ b/romanisim/l3.py
@@ -142,7 +142,7 @@ def inject_sources_into_l3(model, cat, x=None, y=None, psf=None, rng=None,
         rng = galsim.UniformDeviate(seed)
 
     if x is None or y is None:
-        x, y = model.meta.wcs.numerical_inverse(cat['ra'], cat['dec'],
+        x, y = model.meta.wcs.numerical_inverse(cat['ra'].value, cat['dec'].value,
                                                 with_bounding_box=False)
 
     filter_name = model.meta.basic.optical_element
@@ -740,8 +740,8 @@ def add_more_metadata(metadata, efftimes, filter_name, wcs, shape, nexposures):
     metadata['photometry']['conversion_megajanskys'] = 1
 
     cenx, ceny = ((shape[1] - 1) / 2, (shape[0] - 1) / 2)
-    c1 = wcs.pixel_to_world_values(cenx, ceny)
-    c2 = wcs.pixel_to_world_values(cenx + 1, ceny)
+    c1 = wcs.pixel_to_world(cenx, ceny)
+    c2 = wcs.pixel_to_world(cenx + 1, ceny)
     pscale = c1.separation(c2)
 
     metadata['photometry']['pixelarea_steradians'] = (pscale ** 2).to(u.sr)
@@ -769,7 +769,7 @@ def add_more_metadata(metadata, efftimes, filter_name, wcs, shape, nexposures):
     metadata['wcsinfo']['dec_center'] = c1.dec.to(u.degree).value
     xcorn, ycorn = [[0, shape[1] - 1, shape[1] - 1, 0],
                     [0, 0, shape[0] - 1, shape[0] - 1]]
-    ccorn = wcs.pixel_to_world_values(xcorn, ycorn)
+    ccorn = wcs.pixel_to_world(xcorn, ycorn)
     for i, corn in enumerate(ccorn):
         metadata['wcsinfo']['ra_corn{i+1}'] = corn.ra.to(u.degree).value
         metadata['wcsinfo']['dec_corn{i+1}'] = corn.dec.to(u.degree).value

--- a/romanisim/tests/test_l3.py
+++ b/romanisim/tests/test_l3.py
@@ -161,7 +161,7 @@ def test_sim_mosaic():
 
     # Create bounds from the object list
     twcs = romanisim.wcs.get_mosaic_wcs(metadata)
-    allx, ally = twcs.world_to_pixel(cat['ra'], cat['dec'])
+    allx, ally = twcs.world_to_pixel_values(cat['ra'], cat['dec'])
 
     # Obtain the sample extremums
     xmin = min(allx)
@@ -170,7 +170,7 @@ def test_sim_mosaic():
     ymax = max(ally)
 
     # Obtain WCS center
-    xcen, ycen = twcs.world_to_pixel(ra_ref, dec_ref)
+    xcen, ycen = twcs.world_to_pixel_values(ra_ref, dec_ref)
 
     # Determine maximum extremums from WCS center
     xdiff = max([math.ceil(xmax - xcen), math.ceil(xcen - xmin)]) + 1
@@ -191,7 +191,7 @@ def test_sim_mosaic():
     assert len(extras['objinfo']) == len(cat)
 
     # Ensure center pixel of bright objects is bright
-    x_all, y_all = moswcs.world_to_pixel(cat['ra'][:10], cat['dec'][:10])
+    x_all, y_all = moswcs.world_to_pixel_values(cat['ra'][:10], cat['dec'][:10])
     for x, y in zip(x_all, y_all):
         x = int(x)
         y = int(y)
@@ -581,7 +581,7 @@ def test_scaling():
     # pixel scales are different by a factor of two.
     fluxes = []
     for im, fac in zip((im1, im2, im3), (1, 2, 1)):
-        pix = im.meta.wcs.world_to_pixel(
+        pix = im.meta.wcs.world_to_pixel_values(
             imdict['tabcatalog']['ra'][0], imdict['tabcatalog']['dec'][0])
         pind = [int(x) for x in pix]
         margin = 30 * fac

--- a/romanisim/tests/test_l3.py
+++ b/romanisim/tests/test_l3.py
@@ -161,7 +161,7 @@ def test_sim_mosaic():
 
     # Create bounds from the object list
     twcs = romanisim.wcs.get_mosaic_wcs(metadata)
-    allx, ally = twcs.world_to_pixel_values(cat['ra'], cat['dec'])
+    allx, ally = twcs.world_to_pixel_values(cat['ra'].value, cat['dec'].value)
 
     # Obtain the sample extremums
     xmin = min(allx)
@@ -191,7 +191,8 @@ def test_sim_mosaic():
     assert len(extras['objinfo']) == len(cat)
 
     # Ensure center pixel of bright objects is bright
-    x_all, y_all = moswcs.world_to_pixel_values(cat['ra'][:10], cat['dec'][:10])
+    x_all, y_all = moswcs.world_to_pixel_values(cat['ra'][:10].value,
+                                                cat['dec'][:10].value)
     for x, y in zip(x_all, y_all):
         x = int(x)
         y = int(y)

--- a/romanisim/tests/test_wcs.py
+++ b/romanisim/tests/test_wcs.py
@@ -110,7 +110,7 @@ def test_wcs_from_fits_header():
     wcs2 = wcs.wcs_from_fits_header(wcs1.header.header)
     xg, yg = np.meshgrid(np.linspace(0, 4088, 100), np.linspace(0, 4088, 100))
     rd1 = np.degrees(wcs1._radec(xg.copy(), yg.copy()))
-    rd2 = wcs2.pixel_to_world(xg.copy(), yg.copy())
+    rd2 = wcs2.pixel_to_world_values(xg.copy(), yg.copy())
     rd1 = SkyCoord(ra=rd1[0] * u.deg, dec=rd1[1] * u.deg, frame=rd2.frame)
     sep = rd1.separation(rd2).to(u.arcsec).value
 
@@ -168,7 +168,7 @@ def test_scale_factor():
     # Create the wcs and generate results
     distortion = make_fake_distortion_function()
     gwcs = wcs.make_wcs(cc, distortion, scale_factor=scale_factor)
-    sky = gwcs.pixel_to_world(grid, grid)
+    sky = gwcs.pixel_to_world_values(grid, grid)
 
     assert all(truth.separation(sky).to(u.arcsec).value < 1e-3)
 
@@ -190,6 +190,6 @@ def test_scale_factor_negative():
     # Create the wcs and generate results
     distortion = make_fake_distortion_function()
     gwcs = wcs.make_wcs(cc, distortion, scale_factor=scale_factor)
-    sky = gwcs.pixel_to_world(grid, grid)
+    sky = gwcs.pixel_to_world_values(grid, grid)
 
     assert all(truth.separation(sky).to(u.arcsec).value < 1e-3)

--- a/romanisim/tests/test_wcs.py
+++ b/romanisim/tests/test_wcs.py
@@ -110,7 +110,7 @@ def test_wcs_from_fits_header():
     wcs2 = wcs.wcs_from_fits_header(wcs1.header.header)
     xg, yg = np.meshgrid(np.linspace(0, 4088, 100), np.linspace(0, 4088, 100))
     rd1 = np.degrees(wcs1._radec(xg.copy(), yg.copy()))
-    rd2 = wcs2.pixel_to_world_values(xg.copy(), yg.copy())
+    rd2 = wcs2.pixel_to_world(xg.copy(), yg.copy())
     rd1 = SkyCoord(ra=rd1[0] * u.deg, dec=rd1[1] * u.deg, frame=rd2.frame)
     sep = rd1.separation(rd2).to(u.arcsec).value
 
@@ -168,7 +168,7 @@ def test_scale_factor():
     # Create the wcs and generate results
     distortion = make_fake_distortion_function()
     gwcs = wcs.make_wcs(cc, distortion, scale_factor=scale_factor)
-    sky = gwcs.pixel_to_world_values(grid, grid)
+    sky = gwcs.pixel_to_world(grid, grid)
 
     assert all(truth.separation(sky).to(u.arcsec).value < 1e-3)
 
@@ -190,6 +190,6 @@ def test_scale_factor_negative():
     # Create the wcs and generate results
     distortion = make_fake_distortion_function()
     gwcs = wcs.make_wcs(cc, distortion, scale_factor=scale_factor)
-    sky = gwcs.pixel_to_world_values(grid, grid)
+    sky = gwcs.pixel_to_world(grid, grid)
 
     assert all(truth.separation(sky).to(u.arcsec).value < 1e-3)

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -516,7 +516,7 @@ def update_photom_keywords(im, gain=None):
     if 'wcs' in im['meta']:
         wcs = im['meta']['wcs']
         cenpix = (im.data.shape[0] // 2, im.data.shape[1] // 2)
-        cc = wcs.pixel_to_world_values(
+        cc = wcs.pixel_to_world(
             (cenpix[0], cenpix[0], cenpix[0] + 1),
             (cenpix[1], cenpix[1] + 1, cenpix[1]))
         angle = (cc[0].position_angle(cc[1]) -

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -516,8 +516,9 @@ def update_photom_keywords(im, gain=None):
     if 'wcs' in im['meta']:
         wcs = im['meta']['wcs']
         cenpix = (im.data.shape[0] // 2, im.data.shape[1] // 2)
-        cc = wcs.pixel_to_world((cenpix[0], cenpix[0], cenpix[0] + 1),
-                                (cenpix[1], cenpix[1] + 1, cenpix[1]))
+        cc = wcs.pixel_to_world_values(
+            (cenpix[0], cenpix[0], cenpix[0] + 1),
+            (cenpix[1], cenpix[1] + 1, cenpix[1]))
         angle = (cc[0].position_angle(cc[1]) -
                  cc[0].position_angle(cc[2]))
         area = (cc[0].separation(cc[1]) * cc[0].separation(cc[2])

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -374,7 +374,7 @@ def wcs_from_fits_header(header):
     # convention in the galsim CelestialWCS object, we delete that here.
     # Success is defined by
     # (GWCS._radec(x, y) ==
-    #  wcs_from_fits_header(GWCS.header.header).pixel_to_world(x, y))
+    #  wcs_from_fits_header(GWCS.header.header).pixel_to_world_values(x, y))
 
     cd = w.wcs.piximg_matrix
 


### PR DESCRIPTION
romanisim was using the wcs.pixel_to_world and world_to_pixel routines when it should have been using the _values versions of those routines.  These routines have become more strict about their inputs; this updates the code to use the _values versions.