### PR TITLE
Updates for putting filters in filenames in romanisim.

### DIFF
--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -153,7 +153,23 @@ read_pattern = {3: [[2], [5], [10], [16], [17]],
                      [95 + x for x in range(32)], 
                      [127 + x for x in range(32)], 
                      [159 + x for x in range(32)], 
-                     [191 + x for x in range(32)], [223]]
+                     [191 + x for x in range(32)], [223]],
+                18: [[x] for x in range(1, 301)],
+
+                # note: these MA tables are not part of the PRD and are intended
+                # only to support DMS testing.  In particular, 110 is a
+                # 16-resultant imaging table needed to demonstrate ramp fitting
+                # performance.
+                # both 109 and 110 have CRDS darks for both spectroscopic and
+                # imaging modes
+                109: [[1], [2, 3], [5, 6, 7], [10, 11, 12, 13],
+                      [15, 16, 17, 18, 19, 20], [21, 22, 23, 24, 25, 26],
+                      [27, 28, 29, 30, 31, 32], [33, 34, 35, 36, 37, 38],
+                      [39, 40, 41, 42, 43], [44]],
+                110: [[1], [2, 3, 4], [5, 6, 7], [8, 9, 10], [11, 12, 13],
+                      [14, 15, 16], [17, 18, 19], [20, 21, 22], [23, 24, 25],
+                      [26, 27, 28], [29, 30, 31], [32, 33, 34], [35, 36, 37],
+                      [38, 39, 40], [41, 42, 43], [44]],
                 }
 
 default_parameters_dictionary = {

--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -3,6 +3,7 @@
 
 from copy import deepcopy
 import os
+import pathlib
 import re
 import defusedxml.ElementTree
 import numpy as np
@@ -264,12 +265,14 @@ def format_filename(filename, sca, bandpass=None, pretend_spectral=None):
     """
     args = []
     kwargs = dict()
-    if '{}' in filename:
+    pname = pathlib.Path(filename)
+    bname = pname.parts[-1]
+    if '{}' in bname:
         args.append(f'wfi{sca:02d}')
-    if '{bandpass}' in filename:
+    if '{bandpass}' in bname:
         bp = bandpass if pretend_spectral is None else pretend_spectral
         kwargs['bandpass'] = bp.lower()
-    return filename.format(*args, **kwargs)
+    return pname.with_name(bname.format(*args, **kwargs))
 
 
 def simulate_image_file(args, metadata, cat, rng=None, persist=None):

--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -237,6 +237,41 @@ def parse_filename(filename):
     return out
 
 
+def format_filename(filename, sca, bandpass=None, pretend_spectral=None):
+    """Add SCA and filter information to a filename.
+
+    This parameter turns a string like out_{}_{bandpass}.asdf into
+    out_wfi01_f184.asdf.  It differs from format(...) calls in that it won't
+    choke if the target filename includes no {} symbols to format.
+
+    If pretend_spectral is set, the bandpass portion is filled out with the
+    value of pretend_spectral rather than the bandpass, so that
+    out_{}_{bandpass}.asdf becomes out_wfi01_grism.asdf, for example, if
+    pretend_bandpass is grism and bandpass is f158.  This is to support
+    creation of files that have metadata that look like spectroscopic files
+    while the actual pixels are simulated with a different optical bandpass.
+
+    Parameters
+    ----------
+    filename : str
+        file name to format
+    sca : int
+        detector to insert into filename
+    bandpass : str
+        optical element to insert into filename
+    pretend_spectral : str
+        pretend that optical observation was made in this spectroscopic mode
+    """
+    args = []
+    kwargs = dict()
+    if '{}' in filename:
+        args.append(f'wfi{sca:02d}')
+    if '{bandpass}' in filename:
+        bp = bandpass if pretend_spectral is None else pretend_spectral
+        kwargs['bandpass'] = bp.lower()
+    return filename.format(*args, **kwargs)
+
+
 def simulate_image_file(args, metadata, cat, rng=None, persist=None):
     """
     Simulate an image and write it to a file.
@@ -260,6 +295,9 @@ def simulate_image_file(args, metadata, cat, rng=None, persist=None):
                     '--stpsf instead.')
         args.stpsf = args.webbpsf
 
+    filename = format_filename(args.filename, args.sca, bandpass=args.bandpass,
+                               pretend_spectral=args.pretend_spectral)
+
     # Simulate image
     im, extras = image.simulate(
         metadata, cat, usecrds=args.usecrds,
@@ -273,7 +311,7 @@ def simulate_image_file(args, metadata, cat, rng=None, persist=None):
     romanisimdict.update(**extras)
     romanisimdict['version'] = romanisim.__version__
 
-    basename = os.path.basename(args.filename)
+    basename = os.path.basename(filename)
     obsdata = parse_filename(basename)
     if obsdata is not None:
         im['meta']['observation'].update(**obsdata)
@@ -296,7 +334,7 @@ def simulate_image_file(args, metadata, cat, rng=None, persist=None):
     af = asdf.AsdfFile()
     af.tree = {'roman': im, 'romanisim': romanisimdict}
 
-    af.write_to(open(args.filename, 'wb'))
+    af.write_to(open(filename, 'wb'))
 
 
 def parse_apt_file(filename):

--- a/romanisim/tests/test_ris_make_utils.py
+++ b/romanisim/tests/test_ris_make_utils.py
@@ -44,6 +44,8 @@ def test_simulate_image_file(tmp_path):
     args.stpsf = False
     args.level = 0
     args.sca = 7
+    args.bandpass = 'F184'
+    args.pretend_spectral = None
     galsim.roman.n_pix = 100
     ris_make_utils.simulate_image_file(args, meta, cat)
     im = asdf.open(args.filename)
@@ -58,3 +60,11 @@ def test_parse_filename():
     assert obs is not None
     assert obs['program'] == 99999
     assert obs['pass'] == 1
+
+
+def test_format_filename():
+    from romanisim.ris_make_utils import format_filename
+    assert 'test' == str(format_filename('test', sca=1))
+    assert 'test_wfi01' == str(format_filename('test_{}', sca=1))
+    assert 'test_wfi01_foo' == str(format_filename(
+        'test_{}_{bandpass}', sca=1, bandpass='foo'))

--- a/romanisim/tests/test_ris_make_utils.py
+++ b/romanisim/tests/test_ris_make_utils.py
@@ -43,6 +43,7 @@ def test_simulate_image_file(tmp_path):
     args.usecrds = False
     args.stpsf = False
     args.level = 0
+    args.sca = 7
     galsim.roman.n_pix = 100
     ris_make_utils.simulate_image_file(args, meta, cat)
     im = asdf.open(args.filename)

--- a/scripts/romancal_make_all_l1s.sh
+++ b/scripts/romancal_make_all_l1s.sh
@@ -1,12 +1,14 @@
-# r0000101001001001001_0001_wfi01 - default for most steps
-# r0000201001001001001_0001_wfi01 - equivalent for spectroscopic data
-# r0000101001001001001_0002_wfi01 - a second resample exposure, only cal step needed
-# r0000101001001001001_0003_wfi01 - for ramp fitting; truncated image
-# r0000201001001001001_0003_wfi01 - for ramp fitting; truncated spectroscopic
+# r0000101001001001001_0001_wfi01_f158 - default for most steps, ma table 109
+# r0000201001001001001_0001_wfi01_f158 - equivalent for spectroscopic data
+# r0000101001001001001_0002_wfi01_f158 - a second resample exposure, only cal step needed
+# r0000101001001001001_0003_wfi01_f158 - for ramp fitting; truncated image
+# r0000201001001001001_0003_wfi01_f158 - for ramp fitting; truncated spectroscopic
 #                                         we need only darkcurrent & ramp fit for these
 #
-# r0000101001001001001_0004_wfi01 - 16 resultant file, ma_table 110
-# r0000201001001001001_0004_wfi01 - 16 resultant spectroscopic file, ma_table 110
+# r0000101001001001001_0004_wfi01_f158 - 16 resultant file, ma table 110
+# r0000201001001001001_0004_wfi01_f158 - 16 resultant spectroscopic file, ma table 110
+
+# r0000301001001001001_0001_wfi01_f158 - prism image, ma table 109
 
 # note that the "spectroscopic" files are really imaging files where the only
 # thing that has been updated is the optical_element and exposure.type.
@@ -14,25 +16,26 @@
 # but I haven't done anything here.
 
 # default image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_uncal.asdf &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf &
 # second image at a different location, different activity
-romanisim-make-image --radec 270.00 66.01 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_uncal.asdf &
+romanisim-make-image --radec 270.00 66.01 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf &
 # default spectroscopic image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_uncal.asdf --pretend-spectral GRISM &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM &
 # truncated image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_{}_uncal.asdf --truncate 6 &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 &
 
 # just do four at a time
 wait
 
-# truncated spectroscopic image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_0003_{}_uncal.asdf --truncate 6 --pretend-spectral GRISM &
+# truncated grism image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 --pretend-spectral GRISM &
+
 # 16 resultant image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_{}_uncal.asdf &
-# truncated spectroscopic image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_{}_uncal.asdf --pretend-spectral GRISM &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_{}_{bandpass}_uncal.asdf &
+# 16 resultant grism image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM &
 
 # prism image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:30:00 --rng_seed 8 --drop-extra-dq r0000301001001001001_0001_{}_uncal.asdf --pretend-spectral PRISM &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:30:00 --rng_seed 8 --drop-extra-dq r0000301001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral PRISM &
 
 wait

--- a/scripts/romancal_make_regtest_l1s.sh
+++ b/scripts/romancal_make_regtest_l1s.sh
@@ -1,12 +1,13 @@
-# r0000101001001001001_0001_wfi01 - default for most steps
-# r0000201001001001001_0001_wfi01 - equivalent for spectroscopic data
-# r0000101001001001001_0002_wfi01 - a second resample exposure, only cal step needed
-# r0000101001001001001_0003_wfi01 - for ramp fitting; truncated image
-# r0000201001001001001_0003_wfi01 - for ramp fitting; truncated spectroscopic
+# r0000101001001001001_0001_wfi01_f158  - default for most steps
+# r0000101001001001001_0002_wfi01_f158  - a second resample exposure, only cal step needed
+# r0000101001001001001_0002_wfi10_f158  - a second resample exposure, only cal step needed, different SCA
+# r0000201001001001001_0001_wfi01_grism - equivalent for spectroscopic data
+# r0000101001001001001_0003_wfi01_f158  - for ramp fitting; truncated image
+# r0000201001001001001_0003_wfi01_grism - for ramp fitting; truncated spectroscopic
 #                                         we need only darkcurrent & ramp fit for these
 #
-# r0000101001001001001_0004_wfi01 - ma_table 110, 16 resultants file
-# r0000201001001001001_0004_wfi01 - ma_table 110, 16 resultant file, spectroscopic
+# r0000101001001001001_0004_wfi01_f158  - ma_table 110, 16 resultants file
+# r0000201001001001001_0004_wfi01_grism - ma_table 110, 16 resultant file, spectroscopic
 
 # note that the "spectroscopic" files are really imaging files where the only
 # thing that has been updated is the optical_element and exposure.type.
@@ -14,20 +15,21 @@
 # but I haven't done anything here.
 
 # default image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_wfi01_uncal.asdf &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf &
 # different location, different exposure
-romanisim-make-image --radec 270.00 66.01 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_wfi01_uncal.asdf &
+romanisim-make-image --radec 270.00 66.01 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf &
 # SCA 10
-romanisim-make-image --radec 270.00 66.01 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_wfi10_uncal.asdf &
+romanisim-make-image --radec 270.00 66.01 --level 1 --sca 10 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf &
 # default spectroscopic image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_wfi01_uncal.asdf --pretend-spectral GRISM &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM &
 # truncated image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_wfi01_uncal.asdf --truncate 6 &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 &
 # truncated spectroscopic image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_0003_wfi01_uncal.asdf --truncate 6 --pretend-spectral GRISM &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 --pretend-spectral GRISM &
+
 # 16 resultant image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_wfi01_uncal.asdf &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_{}_{bandpass}_uncal.asdf &
 # truncated spectroscopic image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_wfi01_uncal.asdf --pretend-spectral GRISM &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM &
 
 wait

--- a/scripts/romanisim-make-catalog
+++ b/scripts/romanisim-make-catalog
@@ -57,7 +57,7 @@ def main():
 
     outfile_name = f'gaia_{args.radecrad[0]:.2f}_{args.radecrad[1]:.2f}_{args.radecrad[2]:.2f}-{args.time}.ecsv'
     if args.output:
-        outfile_name = args.output + ".ecsv"
+        outfile_name = args.output
     gaia.gaia2romanisimcat(r, Time(args.time), fluxfields=set(romanisim.bandpass.galsim2roman_bandpass.values())).write(outfile_name, overwrite=True)
 
 # Call main if run (as opposed to imported as a module)

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -64,7 +64,10 @@ if __name__ == '__main__':
         description='Make a demo image.',
         epilog='EXAMPLE: %(prog)s output_image.asdf',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('filename', type=str, help='output image (asdf)')
+    parser.add_argument('filename', type=str,
+                        help=('output image (asdf).  {} and {bandpass} strings '
+                              'will be automatically populated with detector '
+                              'and bandpass information.'))
     parser.add_argument('--bandpass', type=str, help='bandpass to simulate',
                         default='F087')
     parser.add_argument('--boresight', action='store_true', default=False,
@@ -90,7 +93,7 @@ if __name__ == '__main__':
                         help='Position angle (North towards YIdl) measured at the V2Ref/V3Ref of the aperture used.')
     parser.add_argument('--sca', type=int, default=7, help=(
         'SCA to simulate. Use -1 to generate images for all SCAs; include {} in filename for this mode '
-        'to indicate where the SCA number should be filled, e.g. l1_{}.asdf'))
+        'to indicate where the detector number should be filled, e.g. l1_{}.asdf'))
     parser.add_argument('--usecrds', action='store_true',
                         help='Use CRDS for distortion map')
     parser.add_argument('--webbpsf', action='store_true',

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -26,13 +26,8 @@ def go(args):
 
     if args.sca == -1:
         # simulate all 18 SCAs sequentially
-        origfilename = copy(args.filename)
-        origprevious = copy(args.previous)
         for i in range(1, 19):
             args.sca = i
-            args.filename = origfilename.format(f'wfi{args.sca:02d}')
-            if origprevious is not None:
-                args.previous = origprevious.format(f'wfi{args.sca:02d}')
             go(args)
         return
 
@@ -55,7 +50,8 @@ def go(args):
 
     # Create persistence object
     if args.previous is not None:
-        persist = persistence.Persistence.read(args.previous)
+        prevfn = ris.format_filename(args.previous, args.sca)
+        persist = persistence.Persistence.read(prevfn)
     else:
         persist = persistence.Persistence()
 
@@ -94,7 +90,7 @@ if __name__ == '__main__':
                         help='Position angle (North towards YIdl) measured at the V2Ref/V3Ref of the aperture used.')
     parser.add_argument('--sca', type=int, default=7, help=(
         'SCA to simulate. Use -1 to generate images for all SCAs; include {} in filename for this mode '
-        'to indicate where the SCA number should be filled, e.g. l1_wfi{}.asdf'))
+        'to indicate where the SCA number should be filled, e.g. l1_{}.asdf'))
     parser.add_argument('--usecrds', action='store_true',
                         help='Use CRDS for distortion map')
     parser.add_argument('--webbpsf', action='store_true',

--- a/scripts/romanisim-make-stack
+++ b/scripts/romanisim-make-stack
@@ -181,6 +181,7 @@ def main():
             entry['PLAN'], entry['PASS'], entry['SEGMENT'],
             entry['OBSERVATION'], entry['VISIT'], entry['EXPOSURE'])
         ma_table_number = int(entry['MA_TABLE_NUMBER'])
+        bandpass = entry['BANDPASS']
         if args.force_ma_table_number > 0:
             ma_table_number = args.force_ma_table_number
 
@@ -191,7 +192,7 @@ def main():
             output_file_name = (
                 f'r{program}{plan:02d}{passno:03d}{segment:03d}'
                 f'{observation:03d}{visit:03d}_{exposure:04d}'
-                f'_wfi{sca:02d}_{suffix}.asdf')
+                f'_wfi{sca:02d}_{bandpass.lower()}_{suffix}.asdf')
 
             log.debug(f"output_file_name = {output_file_name}")
 
@@ -215,7 +216,7 @@ def main():
                             line += f" --previous {previous_file_name[sca]}"
 
                 # Add image options for contents of pointing input file
-                line += f" --bandpass {entry['BANDPASS']}"
+                line += f" --bandpass {bandpass}"
                 line += f" --radec {entry['RA']} {entry['DEC']}"
                 line += f" --roll {entry['PA']}"
                 line += f" --ma_table_number {ma_table_number}"


### PR DESCRIPTION
The Roman L1 & L2 file naming scheme was changed to include the filter name in lowercase in the file name.  This PR implements that change in the romanisim regtest file creation routines.  It also tries to make a more general routine for "automatically" getting the bandpass in the filename, supporting filename arguments like
romanisim-make-image out-{}-{bandpass}.asdf
to produce out-wfi01-f087.asdf.  The naming for the SCA argument should have been {sca} in retrospect, but we retain the old API that was used to support
romanisim-make-image out-{}.asdf --sca -1
to trigger generating all 18 SCAs with names like out-wfi01.asdf.

This PR also adds back MA tables 109 and 110.  These are not officially supported as part of the PRD, so they were removed.  But they have spectroscopic & imaging modes and 110 has >= 16 resultants, meaning that they enable DMS testing in a way that the MA tables in the PRD do not (no >= 16 resultant MA tables for imaging, different MA table numbers for imaging & spectroscopy).  We probably need a better way of dealing with that in general but this approach works for now.

An unrelated change to romanisim-make-catalog slipped in allowing romanisim-make-catalog to write out files in formats other than ecsv.