### PR TITLE
Bugfix for upstream

### DIFF
--- a/romanisim/tests/test_catalog.py
+++ b/romanisim/tests/test_catalog.py
@@ -6,6 +6,7 @@ import os
 import pytest
 import numpy as np
 import galsim
+from pathlib import Path
 from romanisim import catalog
 from astropy.coordinates import SkyCoord
 from astropy import units as u
@@ -195,7 +196,7 @@ def test_make_gaia_stars(tmp_path):
 
 @pytest.mark.parametrize("cosmos", [True, False])
 @pytest.mark.parametrize("gaia", [True, False])
-@pytest.mark.parametrize("filename", [None, "romanisim/data/COSMOS2020_CLASSIC_R1_v2.2_p3_Streamlined.fits"])
+@pytest.mark.parametrize("filename", [None, Path(__file__).parent.parent / "data" /"COSMOS2020_CLASSIC_R1_v2.2_p3_Streamlined.fits"])
 @pytest.mark.parametrize("date", [None, Time('2026-01-01T00:00:00')])
 def test_full_table_catalog(cosmos, gaia, filename, date, tmp_path):
     """Test permutations of source population


### PR DESCRIPTION
The setup for this test assumes that the tests are being run from the romanism repo directory, this is not always the case such as when one is constructing test environments for testing romanism with an upstream package