### PR TITLE
More bug fixes for upstream testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
-minversion = 4.6
+minversion = "4.6"
 norecursedirs = [
     "docs/_build",
     "docs/exts",
@@ -94,6 +94,9 @@ doctest_rst = "enabled"
 markers = [
     "soctests: run only the SOC tests in the suite.",
     "bigdata: uses a lot of data.",
+]
+addopts = [
+    "--color=yes",  # Enable colored output by default
 ]
 
 [tool.coverage.run]

--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -6,6 +6,7 @@ based on catalogs of sources in those scenes.
 import dataclasses
 import numpy as np
 import galsim
+from pathlib import Path
 from galsim import roman
 from astropy import coordinates, table
 from astropy import units as u
@@ -247,8 +248,7 @@ def make_cosmos_galaxies(coord,
     if filename:
         cos_cat_all = table.Table.read(filename, format='fits', hdu=1)
     else:
-        dir_in = "romanisim/data/"
-        cos_cat_all = table.Table.read(dir_in + 'COSMOS2020_CLASSIC_R1_v2.2_p3_Streamlined.fits',
+        cos_cat_all = table.Table.read(Path(__file__).parent / "data" / "COSMOS2020_CLASSIC_R1_v2.2_p3_Streamlined.fits",
                                        format='fits', hdu=1)
 
     # Select galaxies

--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -6,7 +6,6 @@ based on catalogs of sources in those scenes.
 import dataclasses
 import numpy as np
 import galsim
-from pathlib import Path
 from galsim import roman
 from astropy import coordinates, table
 from astropy import units as u
@@ -219,6 +218,7 @@ def make_cosmos_galaxies(coord,
     catalog : astropy.Table
         Table for use with table_to_catalog to generate catalog for simulation.
     """
+    from pathlib import Path
 
     if rng is None:
         rng = galsim.UniformDeviate(seed)


### PR DESCRIPTION
I didn't quite fix all the issues with #212, there were some remaining ones. The issue is that the code was implicitly assuming that the default data file for generating a catalog was with stored respect the layout one gets when one clones the repository with the code run from the root of the repository. This does not hold in general as one can run the code outside that layout. The fix is to reference the data file with respect to the module making the call rather than the directory the code is executing in.

Also, I enabled colorized output in the tests by default because its pretty.