### PR TITLE
Replace deepcopy with model.copy to actually make deep copy

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -1054,7 +1054,7 @@ def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, rng=None,
         newramp[:, m], read_pattern,
         gain=gain, flat=1, darkrate=0)
 
-    res = copy.deepcopy(model)
+    res = model.copy()
     res.data[m] = newimage
     res.var_rnoise[m] = readvar
     res.var_poisson[m] = poissonvar


### PR DESCRIPTION
copy.deepcopy(...) does not actually make a deep copy of images.  Replace this with model.copy() in order to actually make a deep copy.

Thanks to Andrea Bellini for identifying the issue.