### PR TITLE
Fix amp33 and wcs to allow pipeline processing

### DIFF
--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -412,6 +412,8 @@ def make_asdf(resultants, dq=None, filepath=None, metadata=None, persistence=Non
     nborder = parameters.nborder
     npix = galsim.roman.n_pix + 2 * nborder
     out = stnode.WfiScienceRaw.create_fake_data(shape=(len(resultants), npix, npix))
+    out['amp33'] = np.zeros((len(resultants), 4096, 128), dtype=out.amp33.dtype)
+
     if metadata is not None:
         out['meta'].update(metadata)
     extras = dict()

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -111,8 +111,10 @@ def get_wcs(image, usecrds=True, distortion=None):
     # If sent a dictionary, create a temporary model for CRDS interface
     if (type(image) is not roman_datamodels.datamodels.ImageModel):
         image_mod = roman_datamodels.datamodels.ImageModel.create_fake_data({"meta": image})
+        shape = (roman.n_pix, roman.n_pix)
     else:
         image_mod = image
+        shape = image.data.shape
 
     sca = int(image_mod.meta.instrument.detector[3:])
     date = astropy.time.Time(image_mod.meta.exposure.start_time)
@@ -139,7 +141,6 @@ def get_wcs(image, usecrds=True, distortion=None):
                        v3_ref=image_mod.meta.wcsinfo.v3_ref,
                        roll_ref=image_mod.meta.wcsinfo.roll_ref,
                        scale_factor=image_mod.meta.velocity_aberration.scale_factor)
-        shape = image_mod.data.shape
         wcs.bounding_box = ((-0.5, shape[-1] - 0.5), (-0.5, shape[-2] - 0.5))
         wcs = GWCS(wcs)
     else:


### PR DESCRIPTION
The migration away from maker_utils ended up having (at least) two unintended consequences:
- amp33 was getting populated as a [n_resultants, 4096, 4096] array instead of the usual [n_resultants, 4096, 128] array.  This inflates the size of the L1 files and leads to breakage in the reference pixel correction step.  We didn't notice this since romanisim itself doesn't actually do anything with amp33.
- mk_level2_image was making a data array with a 4k x 4k shape, but create_fake_data was leaving this 0x0 by default.  The WCS creation was using the size in setting the bounding box, which was leading to a 0x0 bounding box in some cases.

This PR fixes those two issues.