### PR TITLE
Change WFI_{GRISM/PRISM} -> WFI_SPECTRAL product type

### DIFF
--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -322,8 +322,7 @@ def simulate_image_file(args, metadata, cat, rng=None, persist=None):
 
     pretend_spectral = getattr(args, 'pretend_spectral', None)
     if pretend_spectral is not None:
-        im['meta']['exposure']['type'] = (
-            'WFI_' + args.pretend_spectral.upper())
+        im['meta']['exposure']['type'] = 'WFI_SPECTRAL'
         im['meta']['instrument']['optical_element'] = (
             args.pretend_spectral.upper())
         gs = im['meta']['guide_star']


### PR DESCRIPTION
We now use product_type = WFI_SPECTRAL instead of WFI_PRISM / WFI_GRISM; romanisim should populate these correctly.