### PR TITLE
Correct Units in Output Catalog and Comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "crds >=11.16.21",
     "defusedxml >=0.5.0",
     "galsim >=2.5.1",
-    # "roman_datamodels >=0.23.0",
+    # "roman_datamodels >=0.24.0",
     "roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git",
     "gwcs >=0.22.1, <0.24.0",
     "jsonschema >=4.8",

--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -341,13 +341,13 @@ def make_cosmos_galaxies(coord,
     source_pert = np.ones(len(sim_ids))
     source_pert += ((0.2) * rng_numpy.normal(size=len(sim_ids)))
 
-    # Convert fluxes to Jankskys and normalize for zero-point
+    # Convert fluxes to maggies by converting to Jankskys and normalizing for zero-point
     for bandpass in bandpasses:
         # Perturb sources fluxes by 5% per bandwidth
         band_source_pert = ((0.05) * rng_numpy.normal(size=len(sim_ids)))
 
         # Convert fluxes to Jankskys, normalize for zero-point, and apply perturbations
-        out[bandpass] = sim_cat[f'FLUX_{bandpass}'] * (1 + source_pert + band_source_pert) / (3631 * 10**6)
+        out[bandpass] = sim_cat[f'FLUX_{bandpass}'].value * (1 + source_pert + band_source_pert) / (3631 * 10**6)
 
     # Return output table
     return out

--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -346,7 +346,7 @@ def make_cosmos_galaxies(coord,
         # Perturb sources fluxes by 5% per bandwidth
         band_source_pert = ((0.05) * rng_numpy.normal(size=len(sim_ids)))
 
-        # Convert fluxes to Jankskys, normalize for zero-point, and apply perturbations
+        # Convert fluxes to maggies by converting to Jankskys, normalizing for zero-point, and applying perturbations
         out[bandpass] = sim_cat[f'FLUX_{bandpass}'].value * (1 + source_pert + band_source_pert) / (3631 * 10**6)
 
     # Return output table

--- a/romanisim/gaia.py
+++ b/romanisim/gaia.py
@@ -68,5 +68,5 @@ def gaia2romanisimcat(gaiacat, date, refepoch=2016.0, boost_parallax=1,
     outcat['pa'] = -1
     outcat['ba'] = -1
     for field in fluxfields:
-        outcat[field] = 10. ** (-gaiacat['phot_g_mean_mag'] / 2.5)
+        outcat[field] = 10. ** (-gaiacat['phot_g_mean_mag'].value / 2.5)
     return outcat


### PR DESCRIPTION
The old flux units of GAIA and COSMOS tables were being preserved in RSIM catalog output - this PR removes them. It also fixes a couple comments that referred to the output flux being in Janskys, when they are in maggies.