### PR TITLE
Remove gwcs upper pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "galsim >=2.5.1",
     # "roman_datamodels>=0.26.0,<0.27.0",
     "roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git",
-    "gwcs >=0.22.1, <0.24.0",
+    "gwcs >=0.25.0",
     "jsonschema >=4.8",
     "numpy >=1.25",
     "stpsf >=2.1.0",


### PR DESCRIPTION
We had a PR in place to address an issue with gwcs 0.24.0.  We now require gwcs >=0.25.0 and remove this pin.