### PR TITLE
Update CRDS regtest to trigger CRDS ma table reference storage.

### DIFF
--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -615,11 +615,13 @@ def test_make_test_catalog_and_images():
 )
 def test_reference_file_crds_match(level):
     # Set up parameters for simulation run
+    from romanisim import ris_make_utils
     galsim.roman.n_pix = 4088
     metadata = copy.deepcopy(parameters.default_parameters_dictionary)
     metadata['instrument']['detector'] = 'WFI07'
     metadata['instrument']['optical_element'] = 'F158'
     metadata['exposure']['ma_table_number'] = 4
+    ris_make_utils.set_metadata(meta=metadata, date='2027-01-01', usecrds=True)
 
     twcs = wcs.get_wcs(metadata, usecrds=True)
     rd_sca = twcs.toWorld(galsim.PositionD(

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -210,19 +210,25 @@ def add_more_metadata(metadata, usecrds=False):
     if getattr(parameters, 'ma_table_reference', None):
         matab = parameters.ma_table_reference
 
+    if matab is None and usecrds:
+        raise ValueError('ma table reference file is not loaded!')
+
 
     if usecrds:
-        metadata['exposure']['frame_time'] = matab['roman']['science_tables'][f'SCI{manum:04}']['frame_time']
+        tmatab = matab['roman']['science_tables'][f'SCI{manum:04}']
+        metadata['exposure']['frame_time'] = tmatab['frame_time']
 
         # nrsultant in the metadata is defined from set_metadata in ris_make_utils.py
         nresultants = metadata['exposure']['nresultants']
         read_pattern = metadata['exposure'].get(
             'read_pattern',
-            matab['roman']['science_tables'][f'SCI{manum:04}']['science_read_pattern'][nresultants-1])
+            tmatab['science_read_pattern'][nresultants-1])
         openshuttertime = metadata['exposure']['frame_time'] * read_pattern[-1][-1]
 
-        metadata['exposure']['exposure_time'] = matab['roman']['science_tables'][f'SCI{manum:04}']['accumulated_exposure_time'][nresultants-1]
-        metadata['exposure']['effective_exposure_time'] = matab['roman']['science_tables'][f'SCI{manum:04}']['effective_exposure_time'][nresultants-1]
+        metadata['exposure']['exposure_time'] = (
+            tmatab['accumulated_exposure_time'][nresultants - 1])
+        metadata['exposure']['effective_exposure_time'] = (
+            tmatab['effective_exposure_time'][nresultants - 1])
     else:
         metadata['exposure']['frame_time'] = parameters.read_time
 


### PR DESCRIPTION
#224 caused one of the regression tests to fail because that test was incompletely setting up the metadata needed to run files with CRDS now.  This PR addresses that issue.