### PR TITLE
Misc fixes for B19.

### DIFF
--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -518,7 +518,7 @@ def read_one_healpix(filename,
     """
 
     # Open healpix file
-    cat_table = table.Table.read(filename, bandpasses)
+    cat_table = table.Table.read(filename)
 
     # Check for RSIM Gaia catalog
     if 'phot_g_mean_mag' in cat_table.colnames:

--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -198,7 +198,7 @@ def create_catalog(metadata=None, catalog_name=None, bandpasses=['F087'],
                 date = metadata['exposure']['start_time']
             else:
                 # Level 3
-                date = time.Time(metadata['basic']['time_mean_mjd'], format='mjd')
+                date = time.Time(metadata['coadd_info']['time_mean'], format='mjd')
         else:
             date = None
 

--- a/romanisim/tests/test_l3.py
+++ b/romanisim/tests/test_l3.py
@@ -124,8 +124,8 @@ def test_inject_sources_into_mosaic():
     artifactdir = os.environ.get('TEST_ARTIFACT_DIR', None)
     if artifactdir is not None:
         af = asdf.AsdfFile()
-        af.tree = {'l3_mos': l3_mos,
-                   'l3_mos_orig': l3_mos_orig,
+        af.tree = {'l3_mos': l3_mos._instance,
+                   'l3_mos_orig': l3_mos_orig._instance,
                    'source_cat_table': sc_table,
                    }
         af.write_to(os.path.join(artifactdir, 'dms232.asdf'))


### PR DESCRIPTION
This PR has a few miscellaneous fixes I made while doing the artifacts for B19.

@PaulHuwe , can you look at the change to read_one_healpix in particular?  There's a references to bandpasses when calling Table.read(...) that I didn't understand and just deleted; it was generating a deprecation warning.

I also made another update reflecting the L3 metadata changes and made a change to allow the artifacts to write out.