### PR TITLE
Updates to saturation handling, custom config files, read_pattern defaults, WCS handling

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -535,9 +535,10 @@ def simulate_counts(metadata, objlist,
         catalog of simulated objects in image
     """
 
-    read_pattern = metadata['exposure'].get(
-        'read_pattern',
-        parameters.read_pattern[metadata['exposure']['ma_table_number']])
+    if 'read_pattern' in metadata['exposure']:
+        read_pattern = metadata['exposure']['read_pattern']
+    else:
+        read_pattern = parameters.read_pattern[metadata['exposure']['ma_table_number']]
 
     sca = int(metadata['instrument']['detector'][3:])
     exptime = parameters.read_time * read_pattern[-1][-1]
@@ -650,6 +651,11 @@ def gather_reference_data(image_mod, usecrds=False):
         image_mod.meta.ref_file.crds.version = crds.__version__
         image_mod.meta.ref_file.crds.context = crds.get_context_name(
             observatory=image_mod.crds_observatory)
+
+    for reftype, reffile in reffiles.items():
+        if isinstance(reffile, str) and reffile.lower() == 'none':
+            reffiles[reftype] = None
+            out[reftype] = None
 
     # reffiles has all of the reference files / values we know about
 

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -681,13 +681,24 @@ def gather_reference_data(image_mod, usecrds=False):
     if isinstance(out['dark'], u.Quantity):
         out['dark'] = out['dark'].to(u.electron / u.s).value
 
+    if isinstance(reffiles['saturation'], str):
+        saturation = roman_datamodels.datamodels.SaturationRefModel(
+            reffiles['saturation'])
+        saturation = saturation.data[nborder:-nborder, nborder:-nborder].copy()
+        saturation *= u.DN
+        out['saturation'] = saturation
+    else:
+        saturation = None
+
     if isinstance(reffiles['inverselinearity'], str):
         ilin_model = roman_datamodels.datamodels.InverselinearityRefModel(
             reffiles['inverselinearity'])
         out['inverselinearity'] = nonlinearity.NL(
             ilin_model.coeffs[:, nborder:-nborder, nborder:-nborder].copy(),
             ilin_model.dq[nborder:-nborder, nborder:-nborder].copy(),
-            gain=out['gain'])
+            gain=out['gain'],
+            saturation=saturation,
+            inverse=True)
 
     if isinstance(reffiles['linearity'], str):
         lin_model = roman_datamodels.datamodels.LinearityRefModel(
@@ -695,14 +706,8 @@ def gather_reference_data(image_mod, usecrds=False):
         out['linearity'] = nonlinearity.NL(
             lin_model.coeffs[:, nborder:-nborder, nborder:-nborder].copy(),
             lin_model.dq[nborder:-nborder, nborder:-nborder].copy(),
-            gain=out['gain'])
-
-    if isinstance(reffiles['saturation'], str):
-        saturation = roman_datamodels.datamodels.SaturationRefModel(
-            reffiles['saturation'])
-        saturation = saturation.data[nborder:-nborder, nborder:-nborder].copy()
-        saturation *= u.DN
-        out['saturation'] = saturation
+            gain=out['gain'],
+            saturation=saturation)
 
     out['reffiles'] = reffiles
     return out

--- a/romanisim/nonlinearity.py
+++ b/romanisim/nonlinearity.py
@@ -115,7 +115,7 @@ class NL:
     """Keep track of non-linearity and inverse non-linearity coefficients.
 
     """
-    def __init__(self, coeffs, dq=None, gain=None, saturation=None, inverse=False):
+    def __init__(self, coeffs, dq=None, gain=None, saturation=None):
         """Construct an NL class handling non-linearity correction.
 
         Parameters
@@ -131,13 +131,6 @@ class NL:
 
         saturation : float or None
             Saturation level in DN
-
-        inverse: bool
-            True if this corresponds to the inverse linearity correction.
-
-            This changes the interpretation of the saturation keyword, which is
-            always the saturation level in observed DN.  This gets translated
-            internally to linearized DN if inverse is True.
         """
         if dq is None:
             dq = np.zeros(coeffs.shape[1:], dtype='uint32')
@@ -146,17 +139,6 @@ class NL:
 
         self.coeffs, self.dq = repair_coefficients(coeffs, dq)
         self.gain = gain
-
-        if saturation is not None and inverse:
-            new_saturation = evaluate_nl_polynomial(saturation, self.coeffs)
-            m = (new_saturation < 0 * u.DN) | (new_saturation > saturation * 1.5)
-            if np.any(m):
-                log.warning(
-                    f'{np.sum(m)} points with problematic saturation / inverse linearity '
-                    'values; setting saturation of these points to 10 DN!')
-            new_saturation[m] = 10 * u.DN
-            saturation = new_saturation
-
         self.saturation = saturation
 
     def apply(self, counts, electrons=False, reversed=False):

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -475,6 +475,7 @@ def test_simulate():
     filter_name = 'F158'
     meta = util.default_image_meta(time=time, filter_name=filter_name,
                                    coord=coord)
+    wcs.fill_in_parameters(meta, coord)
     sca = int(meta['instrument']['detector'][3:])
 
     chromcat = imdict['chromcatalog']
@@ -658,6 +659,7 @@ def test_inject_source_into_image():
     filt = 'F158'
     meta = util.default_image_meta(coord=coord, filter_name=filt,
                                    detector='WFI07', ma_table=4)
+    wcs.fill_in_parameters(meta, coord)
     rng_seed = 42
     rng = galsim.UniformDeviate(rng_seed)
     cat = catalog.make_dummy_table_catalog(coord, radius=0.1, bandpasses=[filt],
@@ -731,6 +733,7 @@ def test_image_input(tmpdir):
     roman.n_pix = 500
     coord = SkyCoord(270 * u.deg, 66 * u.deg)
     meta = util.default_image_meta(coord=coord, filter_name='F087')
+    wcs.fill_in_parameters(meta, coord)
     imwcs = wcs.get_wcs(meta, usecrds=False)
 
     # make a table of sources for us to render

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -214,7 +214,6 @@ def add_more_metadata(metadata, usecrds=False):
     if matab is None and usecrds:
         raise ValueError('ma table reference file is not loaded!')
 
-
     if usecrds:
         tmatab = matab['roman']['science_tables'][f'SCI{manum:04}']
         metadata['exposure']['frame_time'] = tmatab['frame_time']

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -27,6 +27,7 @@ import astropy.time
 import roman_datamodels
 import gwcs.geometry
 from gwcs import coordinate_frames as cf
+import galsim
 import gwcs.wcs
 import galsim.wcs
 from galsim import roman
@@ -150,7 +151,8 @@ def get_wcs(image, usecrds=True, distortion=None):
         # therefore requires a date.
         wcs_dict = roman.getWCS(world_pos=util.celestialcoord(world_pos),
                                 SCAs=sca,
-                                date=date.datetime)
+                                date=date.datetime,
+                                PA=image_mod.meta.pointing.pa_aperture * galsim.degrees)
         wcs = wcs_dict[sca]
     return wcs
 

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -14,6 +14,11 @@ from astropy.io import fits
 
 
 def go(args):
+    if args.usecrds:
+        # don't use default values
+        for k in parameters.reference_data:
+            parameters.reference_data[k] = None
+
     if args.config is not None:
         # Open and parse overrides file
         with open(args.config, "r") as config_file:
@@ -21,10 +26,6 @@ def go(args):
             combo_dict = parameters.__dict__
             ris.merge_nested_dicts(combo_dict, config)
             parameters.__dict__.update(combo_dict)
-    elif args.usecrds:
-        # don't use default values
-        for k in parameters.reference_data:
-            parameters.reference_data[k] = None
 
     if args.sca == -1:
         # simulate all 18 SCAs sequentially


### PR DESCRIPTION
This PR contains several miscellaneous changes:
* It pulls in the fix to the default MA pattern handling to allow usage of non-default MA tables from @npadmana 's PR.
* It adds a new "none" reference type.  This is different from None in that it will not trigger pulling from CRDS when --usecrds is set; normally reference files set to None are populated from CRDS when --usecrds is set.  This enables disabling particular CRDS reference files in a user configuration file.
* It adds an optional saturation argument to the nonlinearity class.  If set, the counts are clipped to the nonlinearity level before the nonlinearity correction is applied.  The goal here is to avoid doing non-linearity corrections outside the allowed range of the linearity reference file.  
* It computes the "inverse saturation" level using the saturation level and the linearity object, and passes this to the inverse linearity object when it's constructed, so that likewise we can avoid computing inverse linearity relationships outside their allowed range.
* It adds the PA argument to the galsim.roman WCS call; this was previously only supported in CRDS mode.
* It updates some tests to work correctly when not using CRDS; the new PA code relies on the pa_aperture metadata being set, and this was missed in some test code.