### PR TITLE
Improve saturation handling

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -706,8 +706,7 @@ def gather_reference_data(image_mod, usecrds=False):
             if np.any(m):
                 log.warning(
                     f'{np.sum(m)} points with problematic saturation / inverse linearity '
-                    'values; setting saturation of these points to 10 DN!')
-            inv_saturation[m] = 10 * u.DN
+                    'values!')
         else:
             inv_saturation = None
 
@@ -717,7 +716,12 @@ def gather_reference_data(image_mod, usecrds=False):
             ilin_model.coeffs[:, nborder:-nborder, nborder:-nborder].copy(),
             ilin_model.dq[nborder:-nborder, nborder:-nborder].copy(),
             gain=out['gain'],
-            saturation=inv_saturation)
+            saturation=inv_saturation * 1.1)
+        # fudge factor of 10% on the inverse saturation ensures that we'll
+        # continue to fill up pixels above their nominal saturation limits
+        # so that we can robustly see these pixels as saturated.
+        # It relies on the linearity polynomials not going immediately
+        # insane beyond saturation, though.
 
     out['reffiles'] = reffiles
     return out

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -568,7 +568,8 @@ def make_l1(counts, read_pattern,
     # this maybe should be better applied at read time?
     # it's not actually clear to me what the right thing to do
     # is in detail.
-    resultants = np.clip(resultants, 0 * u.DN, saturation)
+    # let things go a little higher than saturation
+    resultants = np.clip(resultants, 0 * u.DN, saturation * 1.1)
     m = resultants >= saturation
     dq[m] |= parameters.dqbits['saturated']
 


### PR DESCRIPTION
#260 introduced an issue where saturated pixels were being mishandled.  This PR changes the handling of saturated pixels in two ways:
1. It does not require the inverse linearity and linearity functions to invert in order for the linearity and inverse linearity simulations to proceed.  I wanted to avoid doing math where the polynomials will go crazy, but if we adjust the saturation limit to achieve that romancal will have to know about it in its processing, or these pixels will fail.  So we might as well continue failing on these pixels and push the problem to fixing the reference files.
2. I was capping the inverse & linearity corrections at the saturation level so that we did not try to reach values past saturation.  When the inverse saturation & saturation limits didn't quite match, this could lead us to cap slightly before saturation and never reach it, leading to weird problematic ramps.  Now we cap at 10% larger than the estimated saturation / inverse saturation limits, which seems to address most of the issue.