### PR TITLE
Handle mixed manual saturation & CRDS linearity case.

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -688,7 +688,7 @@ def gather_reference_data(image_mod, usecrds=False):
         saturation *= u.DN
         out['saturation'] = saturation
     else:
-        saturation = None
+        saturation = out['saturation']
 
     if isinstance(reffiles['linearity'], str):
         lin_model = roman_datamodels.datamodels.LinearityRefModel(
@@ -703,7 +703,8 @@ def gather_reference_data(image_mod, usecrds=False):
         # corrected results
 
     if isinstance(reffiles['inverselinearity'], str):
-        if saturation is not None and 'linearity' in out:
+        if ((saturation is not None) and ('linearity' in out) and
+                (out['linearity'] is not None)):
             inv_saturation = out['linearity'].apply(saturation)
             m = (inv_saturation < 0 * u.DN) | (inv_saturation > saturation * 2)
             if np.any(m):


### PR DESCRIPTION
#262 didn't handle the case where the saturation was set to a manual constant in the parameters file but the linearity and inverse linearity files were not.  This PR makes the reference file handling a bit more robust to that kind of case.