### PR TITLE
Remove ROSES warning

### DIFF
--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -142,11 +142,4 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     log.info('Starting simulation...')
-    log.warning("romanisim is under active development.  Its output has "
-                "not been formally validated; only limited testing has been "
-                "performed.  For this reason, use of romanisim for "
-                "preparation of ROSES proposals is not advised.  Other "
-                "packages like galsim's roman package or STIPS may better "
-                "serve such purposes.")
-
     go(args)

--- a/scripts/romanisim-make-l3
+++ b/scripts/romanisim-make-l3
@@ -54,12 +54,6 @@ if __name__ == '__main__':
 
     log.info(f'Running with args: {args}')
     log.info('Starting simulation...')
-    log.warning("romanisim is under active development.  Its output has "
-                "not been formally validated; only limited testing has been "
-                "performed.  For this reason, use of romanisim for "
-                "preparation of ROSES proposals is not advised.  Other "
-                "packages like galsim's roman package or STIPS may better "
-                "serve such purposes.")
 
     pixscale = args.pixscalefrac * parameters.pixel_scale
     midpoint = (args.npix - 1) / 2

--- a/scripts/romanisim-make-stack
+++ b/scripts/romanisim-make-stack
@@ -112,12 +112,6 @@ def main():
     args = parser.parse_args()
 
     log.info('Starting simulation...')
-    log.warning("romanisim is under active development.  Its output has "
-                "not been formally validated; only limited testing has been "
-                "performed.  For this reason, use of romanisim for "
-                "preparation of ROSES proposals is not advised.  Other "
-                "packages like galsim's roman package or STIPS may better "
-                "serve such purposes.")
 
     if args.config is not None:
         # Open and parse overrides file


### PR DESCRIPTION
This PR removes the warning that is emitted when running romanisim-make-image and relatives.

Closes #274 .  