### PR TITLE
Increase pedestal to make inverse linearity less problematic.

### DIFF
--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -263,7 +263,7 @@ persistence = dict(A=0.017, x0=6.0e4, dx=5.0e4, alpha=0.045, gamma=1,
                    half_well=50000, ignorerate=0.01)
 
 # arbitrary constant to add to initial L1 image so that pixels aren't clipped at zero.
-pedestal = 100 * u.DN
+pedestal = 5000 * u.DN
 
 # Addd this much extra noise as correlated extra noise in all resultants.
 pedestal_extra_noise = 4 * u.DN


### PR DESCRIPTION
This increases the default pedestal level in romanisim in order to avoid exploring problematic regions of the linearity / inverse linearity curves.  With this PR there are still some signatures of the linearity correction in the images:
<img width="695" height="649" alt="image" src="https://github.com/user-attachments/assets/521c3bfa-7727-4613-84a9-1d5634c3472c" />
but they are dramatically reduced relative to the previous pedestal of 100:
<img width="360" height="341" alt="image" src="https://github.com/user-attachments/assets/170c39c6-c50d-43f5-8537-91d80f735087" />
(from @eteq)
