### PR TITLE
Remove usage of private stnode API from RDM

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -19,7 +19,7 @@ import romanisim.bandpass
 import romanisim.psf
 import romanisim.persistence
 
-import roman_datamodels
+from roman_datamodels.datamodels import ImageModel, InverselinearityRefModel, LinearityRefModel, SaturationRefModel, DarkRefModel, GainRefModel, ReadnoiseRefModel, FlatRefModel
 
 
 # galsim fluxes are in photons / cm^2 / s
@@ -708,7 +708,7 @@ def gather_reference_data(image_mod, usecrds=False):
                     image_mod.get_crds_parameters(),
                     reftypes=['flat'], observatory='roman')['flat']
 
-                flat_model = roman_datamodels.datamodels.FlatRefModel(flatfile)
+                flat_model = FlatRefModel(flatfile)
                 flat = flat_model.data[...].copy()
                 image_mod.meta.ref_file['flat'] = (
                     'crds://' + os.path.basename(flatfile))
@@ -731,18 +731,18 @@ def gather_reference_data(image_mod, usecrds=False):
 
     # we now need to extract the relevant fields
     if isinstance(reffiles['readnoise'], str):
-        model = roman_datamodels.datamodels.ReadnoiseRefModel(
+        model = ReadnoiseRefModel(
             reffiles['readnoise'])
         out['readnoise'] = model.data[nborder:-nborder, nborder:-nborder].copy()
         out['readnoise'] *= u.DN
 
     if isinstance(reffiles['gain'], str):
-        model = roman_datamodels.datamodels.GainRefModel(reffiles['gain'])
+        model = GainRefModel(reffiles['gain'])
         out['gain'] = model.data[nborder:-nborder, nborder:-nborder].copy()
         out['gain'] *= u.electron / u.DN
 
     if isinstance(reffiles['dark'], str):
-        model = roman_datamodels.datamodels.DarkRefModel(reffiles['dark'])
+        model = DarkRefModel(reffiles['dark'])
         out['dark'] = model.dark_slope[nborder:-nborder, nborder:-nborder].copy()
         out['dark'] *= u.DN / u.s
         out['dark'] *= out['gain']
@@ -750,7 +750,7 @@ def gather_reference_data(image_mod, usecrds=False):
         out['dark'] = out['dark'].to(u.electron / u.s).value
 
     if isinstance(reffiles['saturation'], str):
-        saturation = roman_datamodels.datamodels.SaturationRefModel(
+        saturation = SaturationRefModel(
             reffiles['saturation'])
         saturation = saturation.data[nborder:-nborder, nborder:-nborder].copy()
         saturation *= u.DN
@@ -759,7 +759,7 @@ def gather_reference_data(image_mod, usecrds=False):
         saturation = out['saturation']
 
     if isinstance(reffiles['linearity'], str):
-        lin_model = roman_datamodels.datamodels.LinearityRefModel(
+        lin_model = LinearityRefModel(
             reffiles['linearity'])
         out['linearity'] = nonlinearity.NL(
             lin_model.coeffs[:, nborder:-nborder, nborder:-nborder].copy(),
@@ -782,7 +782,7 @@ def gather_reference_data(image_mod, usecrds=False):
         else:
             inv_saturation = None
 
-        ilin_model = roman_datamodels.datamodels.InverselinearityRefModel(
+        ilin_model = InverselinearityRefModel(
             reffiles['inverselinearity'])
         out['inverselinearity'] = nonlinearity.NL(
             ilin_model.coeffs[:, nborder:-nborder, nborder:-nborder].copy(),
@@ -862,7 +862,7 @@ def simulate(metadata, objlist,
                     'files from CRDS.  The WCS may be incorrect and up-to-date '
                     'calibration information will not be used.')
 
-    image_mod = roman_datamodels.datamodels.ImageModel.create_fake_data()
+    image_mod = ImageModel.create_fake_data()
     meta = image_mod.meta
     meta['wcs'] = None
 
@@ -983,7 +983,7 @@ def make_asdf(slope, slopevar_rn, slopevar_poisson, metadata=None,
     """
 
     n_groups = len(metadata['exposure']['read_pattern'])
-    out = roman_datamodels.stnode.WfiImage.create_fake_data()
+    out = ImageModel._node_type.create_fake_data()
     # ephemeris contains a lot of angles that could be computed.
     # exposure contains
     #     ngroups, nframes, sca_number, gain_factor, integration_time,

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -111,6 +111,8 @@ from . import log
 from astropy import units as u
 from . import cr
 
+from roman_datamodels.datamodels import ScienceRawModel
+
 
 def validate_times(tij):
     """Verify that a set of times tij is ascending.
@@ -408,10 +410,9 @@ def make_asdf(resultants, dq=None, filepath=None, metadata=None, persistence=Non
         including DQ images and persistence information.
     """
 
-    from roman_datamodels import stnode
     nborder = parameters.nborder
     npix = galsim.roman.n_pix + 2 * nborder
-    out = stnode.WfiScienceRaw.create_fake_data(shape=(len(resultants), npix, npix))
+    out = ScienceRawModel._node_type.create_fake_data(shape=(len(resultants), npix, npix))
     out['amp33'] = np.zeros((len(resultants), 4096, 128), dtype=out.amp33.dtype)
 
     if metadata is not None:

--- a/romanisim/l3.py
+++ b/romanisim/l3.py
@@ -18,9 +18,8 @@ import romanisim.psf
 import romanisim.image
 import romanisim.persistence
 import romanisim.parameters
+from roman_datamodels.datamodels import MosaicModel
 import romanisim.util
-import roman_datamodels.datamodels as rdm
-from roman_datamodels.stnode import WfiMosaic
 import astropy.units as u
 import astropy
 from galsim import roman
@@ -71,7 +70,7 @@ def add_objects_to_l3(l3_mos, source_cat, exptimes, xpos, ypos, psf,
         filter_name = l3_mos.meta.instrument.optical_element
 
     # Create Image canvas to add objects to
-    if isinstance(l3_mos, (rdm.MosaicModel, WfiMosaic)):
+    if isinstance(l3_mos, (MosaicModel, MosaicModel._node_type)):
         sourcecountsall = galsim.ImageF(
             np.array(l3_mos.data), wcs=romanisim.wcs.GWCS(l3_mos.meta.wcs),
             xmin=0, ymin=0)
@@ -87,7 +86,7 @@ def add_objects_to_l3(l3_mos, source_cat, exptimes, xpos, ypos, psf,
         rng=rng, seed=seed, add_noise=True)
 
     # Save array with added sources
-    if isinstance(l3_mos, (rdm.MosaicModel, WfiMosaic)):
+    if isinstance(l3_mos, (MosaicModel, MosaicModel._node_type)):
         l3_mos.data = sourcecountsall.array
 
     return outinfo
@@ -342,7 +341,7 @@ def simulate(shape, wcs, efftimes, filter_name, catalog, nexposures=1,
     """
 
     # Create metadata object
-    mosaic_node = WfiMosaic.create_fake_data()
+    mosaic_node = MosaicModel._node_type.create_fake_data()
     meta = mosaic_node.meta
 
     # add romanisim defaults

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -28,7 +28,7 @@ import asdf
 from astropy.modeling.functional_models import Sersic2D
 import pytest
 from romanisim import log
-from roman_datamodels.stnode import WfiScienceRaw, WfiImage
+from roman_datamodels.datamodels import ImageModel, ScienceRawModel
 import romanisim.bandpass
 
 
@@ -641,10 +641,10 @@ def test_reference_file_crds_match(level):
     assert im.meta.ref_file.crds.version != '12.3.1'
 
     if (level == 1):
-        assert (type(im) is WfiScienceRaw)
+        assert (type(im) is ScienceRawModel._node_type)
     else:
         # level = 2
-        assert (type(im) is WfiImage)
+        assert (type(im) is ImageModel._node_type)
 
 
 @pytest.mark.soctests


### PR DESCRIPTION
spacetelescope/roman_datamodels#614 makes the `stnode` API private. This PR updates `romanisim` to not use this deprecated API so that the unit tests in RCAL do not fail due to deprecation warnings.