### PR TITLE
Convert Quantity inputs to the units of the coordinate frame

### DIFF
--- a/romanisim/tests/test_wcs.py
+++ b/romanisim/tests/test_wcs.py
@@ -57,6 +57,11 @@ def test_wcs():
                        [cc2.ra / galsim.degrees, cc2.dec / galsim.degrees])
     pos2 = wcsgalsim.toImage(cc1)
     assert np.allclose([pos.x, pos.y], [pos2.x, pos2.y])
+
+    # Using direct unit input to Galsim we should get identical results
+    pos3 = wcsgalsim.toImage(cc1.ra.deg, cc1.dec.deg, units="deg")
+    assert np.all((pos2.x, pos2.y) == pos3)
+ 
     # also try some arrays
     xx = np.random.uniform(0, 4096, 100)
     yy = np.random.uniform(0, 4096, 100)

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -293,10 +293,12 @@ class GWCS(galsim.wcs.CelestialWCS):
             return r, d
 
     def _xy(self, ra, dec, color=None):
-        # _xy accepts ra/dec in radians; we decorate r1, d1 appropriately.
-        r1 = np.atleast_1d(ra) * u.rad
-        d1 = np.atleast_1d(dec) * u.rad
+        # _xy accepts ra/dec in radians.
+        # Convert ra/dec to degrees before passing them to the WCS
+        # which defines the output units to be "deg".
 
+        r1 = np.rad2deg(np.atleast_1d(ra))
+        d1 = np.rad2deg(np.atleast_1d(dec))
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             x, y = self.wcs.invert(r1, d1, with_bounding_box=False)


### PR DESCRIPTION
When. the inputs to a GWCS object are quantities, GWCS converts to the units of the corresponding frame. There was a bug in gwcs where this unit conversion was not done and this is fixed now in https://github.com/spacetelescope/gwcs/pull/660