### PR TITLE
Add pedestal before applying nonlinearity

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -94,6 +94,10 @@ def make_l2(resultants, read_pattern, read_noise=None, gain=None, flat=None,
         gain = gain * u.electron / u.DN
     gain = gain.astype('f4')
 
+    # Ensure resultants have DN units if they're dimensionless
+    if not isinstance(resultants, u.Quantity):
+        resultants = resultants * u.DN
+
     if linearity is not None:
         resultants = linearity.apply(resultants)
 
@@ -380,10 +384,48 @@ def add_objects_to_image(image, objlist, xpos, ypos, psf,
     return outinfo
 
 
+def flat_to_qe(flat, gain, area=None):
+    """Convert flat field to relative QE.
+
+    The CRDS flat field is area * QE / gain / <(area * QE / gain)>.
+    This function extracts the relative QE component by dividing out
+    the area and gain dependencies and renormalizing.
+
+    Parameters
+    ----------
+    flat : float or np.ndarray
+        Flat field from CRDS
+    gain : float or np.ndarray
+        Gain in electrons/DN (can have astropy units)
+    area : float or np.ndarray, optional
+        Pixel area (collecting area per pixel). If None, assumes area=1.
+        Can be obtained via imwcs.makeSkyImage with sky_level=1.
+
+    Returns
+    -------
+    qe : float or np.ndarray
+        Relative QE normalized so median = 1
+    """
+    if area is None:
+        area = 1
+
+    # Extract numerical value from gain if it has units
+    if hasattr(gain, 'value'):
+        gain = gain.value
+
+    # Remove gain and area dependencies
+    qe = flat * gain / area
+
+    # Renormalize so median is 1
+    qe = qe / np.median(qe)
+
+    return qe
+
+
 def simulate_counts_generic(image, exptime, objlist=None, psf=None,
                             zpflux=None,
                             sky=None, dark=None,
-                            flat=None, xpos=None, ypos=None,
+                            qe=None, xpos=None, ypos=None,
                             ignore_distant_sources=10, bandpass=None,
                             filter_name=None, rng=None, seed=None,
                             **kwargs):
@@ -403,9 +445,9 @@ def simulate_counts_generic(image, exptime, objlist=None, psf=None,
     * objlist: a list of CatalogObjects to render, or a Table.  Can be chromatic
       or not.  This will have all your normal PSF and galaxy profiles.
     * sky: a sky background model.  This is different from a dark in that
-      it is sensitive to the flat field.
+      it is sensitive to the quantum efficiency (QE).
     * dark: a dark model.
-    * flat: a flat field for modulating the object and sky electrons
+    * qe: relative quantum efficiency for modulating the object and sky electrons
 
     Parameters
     ----------
@@ -423,7 +465,7 @@ def simulate_counts_generic(image, exptime, objlist=None, psf=None,
         Image or constant with the electrons / pix / sec from sky.
     dark : float or array_like
         Image or constant with the electrons / pix / sec from dark current.
-    flat : array_like
+    qe : array_like
         Image giving the relative QE of different pixels.
     xpos, ypos : array_like (float)
         x, y positions of each source in objlist
@@ -481,25 +523,27 @@ def simulate_counts_generic(image, exptime, objlist=None, psf=None,
     if len(objlist) > 0 and psf is None:
         raise ValueError('Must provide a PSF if you want to render objects.')
 
-    if flat is None:
-        flat = 1
+    if qe is None:
+        qe = 1
 
     # for some reason, galsim doesn't like multiplying an SED by 1, but it's
     # okay with multiplying an SED by 1.0, so we cast to float.
-    maxflat = float(np.max(flat))
-    if maxflat > 1.1:
-        log.warning('max(flat) > 1.1; this seems weird?!')
-    if maxflat > 2:
-        log.error('max(flat) > 2; this seems really weird?!')
-    # how to deal with the flat field?  We artificially inflate the
-    # exposure time of each source by maxflat when rendering.  And then we
+    maxqe = float(np.max(qe))
+    if maxqe > 1.1:
+        log.warning('max(qe) > 1.1; this seems weird?!')
+    nbad = np.sum(qe > 2)
+    if nbad > 0:
+        log.warning(f'Found {nbad} pixels with implied qe > 2; clipping these to qe 2')
+        qe = np.clip(qe, 0, 2)
+    # how to deal with the QE?  We artificially inflate the
+    # exposure time of each source by maxqe when rendering.  And then we
     # do a binomial sampling of the total number of photons obtained per pixel
     # to figure out how many "should" have entered the pixel.
 
     chromatic = False
     if len(objlist) > 0 and objlist[0].profile.spectral:
         chromatic = True
-    flux_to_counts_factor = exptime * maxflat
+    flux_to_counts_factor = exptime * maxqe
     if not chromatic:
         flux_to_counts_factor *= zpflux
     xposk = xpos[keep] if xpos is not None else None
@@ -525,11 +569,11 @@ def simulate_counts_generic(image, exptime, objlist=None, psf=None,
 
     if sky is not None:
         workim = image * 0
-        workim += sky * maxflat * exptime
+        workim += sky * maxqe * exptime
         workim.addNoise(poisson_noise)
         image += workim
 
-    if not np.all(flat == 1):
+    if not np.all(qe == 1):
         image.quantize()
         rng_numpy_seed = rng.raw()
         rng_numpy = np.random.default_rng(rng_numpy_seed)
@@ -544,7 +588,7 @@ def simulate_counts_generic(image, exptime, objlist=None, psf=None,
         # point number, which is roughly 2^31 - 128.
         MAX_SAFE_VALUE = np.nextafter(2**31 - 1, 0, dtype=np.float32)
         image.array[:, :] = rng_numpy.binomial(
-            np.clip(image.array, 0, MAX_SAFE_VALUE).astype("i4"), flat / maxflat
+            np.clip(image.array, 0, MAX_SAFE_VALUE).astype("i4"), qe / maxqe
         )
 
     if dark is not None:
@@ -561,7 +605,7 @@ def simulate_counts(metadata, objlist,
                     rng=None, seed=None,
                     ignore_distant_sources=10, usecrds=True,
                     psftype='galsim',
-                    darkrate=None, flat=None,
+                    darkrate=None, flat=None, gain=None,
                     psf_keywords=dict()):
     """Simulate total electrons in a single SCA.
 
@@ -589,7 +633,9 @@ def simulate_counts(metadata, objlist,
     darkrate : float or np.ndarray[float]
         dark rate image to use (electrons / s)
     flat : float or np.ndarray[float]
-        flat field to use
+        flat field
+    gain : float or np.ndarray[float]
+        gain (electrons / DN)
     psf_keywords : dict
         keywords passed to PSF generation routine
 
@@ -640,12 +686,28 @@ def simulate_counts(metadata, objlist,
     sky_level *= (1.0 + roman.stray_light_fraction)
     sky_image = image * 0
     imwcs.makeSkyImage(sky_image, sky_level)
+    # Extract pixel area from sky image (before adding thermal backgrounds)
+    # makeSkyImage multiplies sky_level by pixel area, so area = sky_image / sky_level
+    area = sky_image.array / sky_level
     sky_image += roman.thermal_backgrounds[galsim_filter_name]
     abflux = romanisim.bandpass.get_abflux(filter_name, sca)
 
+    # Convert flat field to QE
+    if gain is None:
+        gain = parameters.reference_data.get('gain', 1)
+    if flat is None:
+        flat = parameters.reference_data.get('flat', 1)
+    # Handle case where flat or gain exist in dict but are None
+    if flat is None:
+        flat = 1
+    if gain is None:
+        gain = 1
+
+    qe = flat_to_qe(flat, gain, area=area)
+
     simcatobj = simulate_counts_generic(
         image, exptime, objlist=objlist, psf=psf, zpflux=abflux, sky=sky_image,
-        dark=darkrate, flat=flat,
+        dark=darkrate, qe=qe,
         ignore_distant_sources=ignore_distant_sources, bandpass=bandpass,
         filter_name=filter_name, rng=rng, seed=seed)
 
@@ -906,7 +968,7 @@ def simulate(metadata, objlist,
     log.info('Simulating filter {0}...'.format(filter_name))
     counts, simcatobj = simulate_counts(
         image_mod.meta, objlist, rng=rng, usecrds=usecrds, darkrate=darkrate,
-        psftype=psftype, flat=flat, psf_keywords=psf_keywords)
+        psftype=psftype, flat=flat, gain=gain, psf_keywords=psf_keywords)
 
     # If extra_counts is passed in, add directly to counts
     if extra_counts is not None:

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -173,7 +173,8 @@ def tij_to_pij(tij, remaining=False):
 
 
 def apportion_counts_to_resultants(
-        counts, tij, inv_linearity=None, crparam=None, persistence=None,
+        counts, tij, pedestal=None, pedestal_extra_noise=None,
+        inv_linearity=None, crparam=None, persistence=None,
         tstart=None, rng=None, seed=None):
     """Apportion counts to resultants given read times.
 
@@ -195,6 +196,10 @@ def apportion_counts_to_resultants(
       where to start the next resultant
     * the resultants so far
 
+    An initial reset level can be supported by setting the pedestal and
+    pedestal extra noise levels.  These need to be correct to probe the correct
+    portion of the linearity & inverse linearity polynomials.
+
     Parameters
     ----------
     counts : np.ndarray[ny, nx] (int)
@@ -205,6 +210,10 @@ def apportion_counts_to_resultants(
         included beyond PSF & distortion.
     tij : list[list[float]]
         list of lists of readout times for each read entering a resultant
+    pedestal: int
+        initial instrumental count level (electrons)
+    pedestal_extra_noise: float
+        pedestal noise (electrons)
     inv_linearity : romanisim.nonlinearity.NL or None
         Object implementing inverse non-linearity correction
     crparam : dict
@@ -245,8 +254,9 @@ def apportion_counts_to_resultants(
     rng_numpy = np.random.default_rng(rng_numpy_seed)
     rng_numpy_cr = np.random.default_rng(rng_numpy_seed + 1)
     rng_numpy_ps = np.random.default_rng(rng_numpy_seed + 2)
-    # two separate generators so that if you turn off CRs / persistence
-    # you don't change the image
+    rng_numpy_pedestal = np.random.default_rng(rng_numpy_seed + 3)
+    # separate generators so that turning on/off CRs / persistence / pedestal noise
+    # doesn't change the other random sequences
 
     # Convert readout times for each read entering a resultant to probabilities,
     # corresponding to the chance that a photon not yet assigned to a read so far
@@ -259,11 +269,18 @@ def apportion_counts_to_resultants(
     resultant_counts = np.zeros(counts.shape, dtype='f4')
     dq = np.zeros(resultants.shape, dtype=np.uint32)
 
-    # Set initial instrument counts
-    instrumental_so_far = 0
+    # Set initial instrument counts (always create as array for simplicity)
+    # Includes pedestal (detector reset level) and instrumental effects
+    instrumental_so_far = np.zeros(counts.shape, dtype='f4')
 
-    if crparam is not None or persistence is not None:
-        instrumental_so_far = np.zeros(counts.shape, dtype='i4')
+    # Add pedestal (detector reset level in electrons) if specified
+    if pedestal is not None:
+        instrumental_so_far += pedestal
+
+    # Add pedestal noise if specified (sampled once per pixel)
+    if pedestal_extra_noise is not None:
+        pedestal_noise = rng_numpy_pedestal.normal(0, pedestal_extra_noise, counts.shape)
+        instrumental_so_far += pedestal_noise
 
     if persistence is not None and tstart is None:
         raise ValueError('tstart must be set if persistence is set!')
@@ -321,13 +338,16 @@ def apportion_counts_to_resultants(
 
 
 def add_read_noise_to_resultants(resultants, tij, read_noise=None, rng=None,
-                                 seed=None, pedestal_extra_noise=None):
+                                 seed=None):
     """Adds read noise to resultants.
 
     The resultants get Gaussian read noise with sigma = sigma_read/sqrt(N).
     This is not quite right.  In reality read noise is added during each read.
     This is the same as adding to the resultants and dividing by sqrt(N) except
     for quantization; this additional subtlety is currently ignored.
+
+    Note: Pedestal noise is now added in apportion_counts_to_resultants before
+    non-linearity is applied, not here.
 
     Parameters
     ----------
@@ -341,9 +361,6 @@ def add_read_noise_to_resultants(resultants, tij, read_noise=None, rng=None,
         Random number generator to use
     seed : int
         Seed for populating RNG.  Only used if rng is None.
-    pedestal_extra_noise : float
-        Extra read noise to add to each pixel across all groups.
-        Equivalent to noise in the reference read.
 
     Returns
     -------
@@ -359,9 +376,6 @@ def add_read_noise_to_resultants(resultants, tij, read_noise=None, rng=None,
     else:
         rng = galsim.GaussianDeviate(rng)
 
-    # separate noise generator for pedestals so we can turn it on and off.
-    pedestalrng = galsim.GaussianDeviate(rng.raw())
-
     if read_noise is None:
         read_noise = parameters.reference_data['readnoise']
     if read_noise is None:
@@ -373,12 +387,6 @@ def add_read_noise_to_resultants(resultants, tij, read_noise=None, rng=None,
     noise = noise * read_noise / np.array(
         [len(x)**0.5 for x in tij]).reshape(-1, 1, 1)
     resultants += noise
-
-    if pedestal_extra_noise is not None:
-        noise = np.zeros(resultants.shape[1:], dtype='f4')
-        amplitude = np.hypot(pedestal_extra_noise, read_noise)
-        pedestalrng.generate(noise)
-        resultants += noise[None, ...] * amplitude
 
     return resultants
 
@@ -477,7 +485,7 @@ def add_ipc(resultants, ipc_kernel=None):
 
 
 def make_l1(counts, read_pattern,
-            read_noise=None, pedestal_extra_noise=None,
+            read_noise=None, pedestal=None, pedestal_extra_noise=None,
             rng=None, seed=None,
             gain=None, inv_linearity=None, crparam=None,
             persistence=None, tstart=None, saturation=None):
@@ -495,6 +503,8 @@ def make_l1(counts, read_pattern,
         resultant.
     read_noise : np.ndarray[ny, nx] (float) or float
         Read noise entering into each read
+    pedestal : np.ndarray[ny, nx] (float) or float
+        Reset level in electrons
     pedestal_extra_noise : np.ndarray[ny, nx] (float) or float
         Extra noise entering into each pixel (i.e., degenerate with pedestal)
     rng : galsim.BaseDeviate
@@ -523,9 +533,18 @@ def make_l1(counts, read_pattern,
     """
 
     tij = read_pattern_to_tij(read_pattern)
+
+    # Set defaults for pedestal parameters if not specified
+    if pedestal is None:
+        pedestal = parameters.pedestal
+    if pedestal_extra_noise is None:
+        pedestal_extra_noise = parameters.pedestal_extra_noise
+
     log.info('Apportioning electrons to resultants...')
     resultants, dq = apportion_counts_to_resultants(
-        counts.array, tij, inv_linearity=inv_linearity, crparam=crparam,
+        counts.array, tij,
+        pedestal=pedestal, pedestal_extra_noise=pedestal_extra_noise,
+        inv_linearity=inv_linearity, crparam=crparam,
         persistence=persistence, tstart=tstart,
         rng=rng, seed=seed)
 
@@ -553,17 +572,15 @@ def make_l1(counts, read_pattern,
     log.info('Adding read noise...')
     resultants = add_read_noise_to_resultants(
         resultants, tij, rng=rng, seed=seed,
-        read_noise=read_noise,
-        pedestal_extra_noise=pedestal_extra_noise)
+        read_noise=read_noise)
 
     # quantize
     resultants = np.round(resultants)
 
-    # add pedestal
-    resultants += parameters.pedestal
-
     if saturation is None:
         saturation = parameters.reference_data['saturation']
+    if not isinstance(saturation, u.Quantity):
+        saturation = saturation * u.DN
 
     # this maybe should be better applied at read time?
     # it's not actually clear to me what the right thing to do

--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -263,11 +263,9 @@ persistence = dict(A=0.017, x0=6.0e4, dx=5.0e4, alpha=0.045, gamma=1,
                    half_well=50000, ignorerate=0.01)
 
 # Initial detector reset level in electrons (before non-linearity is applied).
-# Old value was 5000 DN; converting with typical gain of 2 electron/DN gives 10000 electrons.
 pedestal = 10000
 
 # Extra noise in the pedestal/reset level in electrons (correlated across all resultants).
-# Old value was 4 DN; converting with typical gain of 2 electron/DN gives 8 electrons.
 pedestal_extra_noise = 8
 
 dqbits = dict(saturated=2, jump_det=4, nonlinear=2**16, no_lin_corr=2**20)

--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -262,11 +262,13 @@ v2v3_wficen = (1546.3846181707652, -892.7916365721071)  # arcsec
 persistence = dict(A=0.017, x0=6.0e4, dx=5.0e4, alpha=0.045, gamma=1,
                    half_well=50000, ignorerate=0.01)
 
-# arbitrary constant to add to initial L1 image so that pixels aren't clipped at zero.
-pedestal = 5000 * u.DN
+# Initial detector reset level in electrons (before non-linearity is applied).
+# Old value was 5000 DN; converting with typical gain of 2 electron/DN gives 10000 electrons.
+pedestal = 10000
 
-# Addd this much extra noise as correlated extra noise in all resultants.
-pedestal_extra_noise = 4 * u.DN
+# Extra noise in the pedestal/reset level in electrons (correlated across all resultants).
+# Old value was 4 DN; converting with typical gain of 2 electron/DN gives 8 electrons.
+pedestal_extra_noise = 8
 
 dqbits = dict(saturated=2, jump_det=4, nonlinear=2**16, no_lin_corr=2**20)
 dq_do_not_use = dqbits['saturated'] | dqbits['jump_det']


### PR DESCRIPTION
This PR improves the accuracy of romanisim simulations by fixing two issues:
  1. Apply detector reset level (pedestal) before inverse linearity correction, so that the linearity polynomial has the total number of electrons in each pixel.
  2. Extract only the QE component from the flat field for photon simulation

romanisim had previously treated the pedestal as something that could be added on to all of the resultants post-facto, but this isn't quite right because the non-linearity polynomials care about the total number of counts in each pixel.  The pedestal is now handled as an additional 'instrumental' source of electrons in each pixel during apportion_counts_to_resultants.

The other thing this PR does is change the flat field handling.  Formerly the flat field was treated as a QE.  But the CRDS flat field is the combination of different pixel areas, different pixel QEs, and different gains.  The gain part was particularly important; without this PR, the gain was getting applied during the electron -> DN conversion, but it was never being calibrated out because romancal / romanisim L1 -> L2 pipelines don't apply the gain (because the flat field is supposed to include it).  Now when romanisim gets a flat field it removes the gain in order to interpret the flat field only as a QE, and then later uses the gain separately when converting from photons to DN.

Tests were also updated to accommodate these changes.

@eteq , this is intended to fix the issues you had seen with residual striping.