### PR TITLE
Remove astropy units for electron and DN

### DIFF
--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -61,28 +61,30 @@ def make_l2(resultants, read_pattern, read_noise=None, gain=None, flat=None,
     Parameters
     ----------
     resultants : np.ndarray[nresultants, ny, nx]
-        resultants array
+        Resultants array in DN
     read_pattern : list[list] (int)
-        list of lists of indices of reads entering each resultant
-    read_noise : np.ndarray[ny, nx] (float)
-        read_noise image to use.  If None, use galsim.roman.read_noise.
-    flat : np.ndarray[ny, nx] (float)
-        flat field to use
-    linearity : romanisim.nonlinearity.NL object or None
-        non-linearity correction to use.
-    darkrate : np.ndarray[ny, nx] (float)
-        dark rate image to subtract from ramps (electron / s)
-    dq : np.ndarray[nresultants, ny, nx] (int)
+        List of lists of indices of reads entering each resultant
+    read_noise : np.ndarray[ny, nx] (float), optional
+        Read noise in DN. If None, use parameters.reference_data['readnoise'].
+    gain : float or np.ndarray, optional
+        Gain in electron/DN. If None, use parameters.reference_data['gain'].
+    flat : np.ndarray[ny, nx] (float), optional
+        Flat field to use
+    linearity : romanisim.nonlinearity.NL object, optional
+        Non-linearity correction to use.
+    darkrate : np.ndarray[ny, nx] (float), optional
+        Dark current rate in electron/s to subtract from ramps
+    dq : np.ndarray[nresultants, ny, nx] (int), optional
         DQ image corresponding to resultants
 
     Returns
     -------
     im : np.ndarray
-        best fitting slopes
+        Best fitting slopes in DN/s
     var_rnoise : np.ndarray
-        variance in slopes from read noise
+        Variance in slopes from read noise in (DN/s)^2
     var_poisson : np.ndarray
-        variance in slopes from source noise
+        Variance in slopes from source noise in (DN/s)^2
     """
 
     if read_noise is None:
@@ -121,19 +123,10 @@ def make_l2(resultants, read_pattern, read_noise=None, gain=None, flat=None,
     if darkrate is not None:
         ramppar[..., 1] -= darkrate
 
-    if isinstance(gain, u.Quantity):
-        gain = gain.value  # no values make sense except for electron / DN
-
-    # The ramp fitter is not presently unit-aware; fix up the units by hand.
-    # To do this right the ramp fitter should be made unit aware.
-    # It takes a bit of work to get this right because we use the fact
-    # that the variance of a Poisson distribution is equal to its mean,
-    # which isn't true as soon as things start having units and requires
-    # special handling.  And we use read_time without units a lot throughout
-    # the code base.
-    slopes = ramppar[..., 1] / gain * u.DN / u.s
-    readvar = rampvar[..., 0, 1, 1] / gain**2 * (u.DN / u.s)**2
-    poissonvar = rampvar[..., 1, 1, 1] / gain**2 * (u.DN / u.s)**2
+    # Ramp fitter works in electrons, convert slopes and variances to DN/s
+    slopes = ramppar[..., 1] / gain  # DN/s
+    readvar = rampvar[..., 0, 1, 1] / gain**2  # (DN/s)^2
+    poissonvar = rampvar[..., 1, 1, 1] / gain**2  # (DN/s)^2
 
     if flat is not None:
         flat = np.clip(flat, 1e-9, np.inf).astype('f4')
@@ -734,26 +727,23 @@ def gather_reference_data(image_mod, usecrds=False):
         model = ReadnoiseRefModel(
             reffiles['readnoise'])
         out['readnoise'] = model.data[nborder:-nborder, nborder:-nborder].copy()
-        out['readnoise'] *= u.DN
+        # readnoise in DN
 
     if isinstance(reffiles['gain'], str):
         model = GainRefModel(reffiles['gain'])
         out['gain'] = model.data[nborder:-nborder, nborder:-nborder].copy()
-        out['gain'] *= u.electron / u.DN
+        # gain in electron/DN
 
     if isinstance(reffiles['dark'], str):
         model = DarkRefModel(reffiles['dark'])
-        out['dark'] = model.dark_slope[nborder:-nborder, nborder:-nborder].copy()
-        out['dark'] *= u.DN / u.s
-        out['dark'] *= out['gain']
-    if isinstance(out['dark'], u.Quantity):
-        out['dark'] = out['dark'].to(u.electron / u.s).value
+        # dark_slope from CRDS is in DN/s, convert to electron/s
+        out['dark'] = model.dark_slope[nborder:-nborder, nborder:-nborder].copy() * out['gain']
 
     if isinstance(reffiles['saturation'], str):
         saturation = SaturationRefModel(
             reffiles['saturation'])
         saturation = saturation.data[nborder:-nborder, nborder:-nborder].copy()
-        saturation *= u.DN
+        # saturation in DN
         out['saturation'] = saturation
     else:
         saturation = out['saturation']
@@ -774,7 +764,7 @@ def gather_reference_data(image_mod, usecrds=False):
         if ((saturation is not None) and ('linearity' in out) and
                 (out['linearity'] is not None)):
             inv_saturation = out['linearity'].apply(saturation)
-            m = (inv_saturation < 0 * u.DN) | (inv_saturation > saturation * 2)
+            m = (inv_saturation < 0) | (inv_saturation > saturation * 2)
             if np.any(m):
                 log.warning(
                     f'{np.sum(m)} points with problematic saturation / inverse linearity '
@@ -1012,13 +1002,13 @@ def make_asdf(slope, slopevar_rn, slopevar_poisson, metadata=None,
 
     util.update_photom_keywords(out, gain=gain)
 
-    out['data'] = slope.value
+    out['data'] = slope
     out['dq'] = np.zeros(slope.shape, dtype='u4')
     if dq is not None:
         out['dq'][:, :] = dq
-    out['var_poisson'] = slopevar_poisson.value
-    out['var_rnoise'] = slopevar_rn.value
-    out['var_flat'] = slopevar_rn.value * 0
+    out['var_poisson'] = slopevar_poisson
+    out['var_rnoise'] = slopevar_rn
+    out['var_flat'] = slopevar_rn * 0
     out['err'] = np.sqrt(out['var_poisson'] + out['var_rnoise'] + out['var_flat'])
     out['amp33'] = np.zeros((n_groups, 4096, 128), dtype=out.amp33.dtype)
     for side in ('left', 'right', 'top', 'bottom'):
@@ -1157,12 +1147,13 @@ def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, rng=None,
     # create injected source ramp resultants
     resultants, dq = romanisim.l1.apportion_counts_to_resultants(
         sourcecounts.array[m], tij, rng=rng)
-    resultants = resultants * u.electron
+    # resultants are in electrons
 
     # Inject source to original image
-    newramp = model.data[None, :] * tbar[:, None, None] * u.DN
-    newramp[:, m] += resultants / gain
-    # newramp has units of DN
+    # model.data is in DN/s, multiply by tbar (time) to get DN
+    newramp = model.data[None, :] * tbar[:, None, None]  # DN
+    newramp[:, m] += resultants / gain  # resultants/gain converts electrons to DN
+    # newramp is in DN
 
     # Make new image of the combination
     newimage, readvar, poissonvar = make_l2(

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -92,13 +92,13 @@ def make_l2(resultants, read_pattern, read_noise=None, gain=None, flat=None,
 
     if gain is None:
         gain = parameters.reference_data['gain']
-    if not isinstance(gain, u.Quantity):
-        gain = gain * u.electron / u.DN
-    gain = gain.astype('f4')
+    # gain in electron/DN
+    try:
+        gain = gain.astype('f4')
+    except AttributeError:  # gain is a scalar
+        gain = np.float32(gain)
 
-    # Ensure resultants have DN units if they're dimensionless
-    if not isinstance(resultants, u.Quantity):
-        resultants = resultants * u.DN
+    # resultants in DN
 
     if linearity is not None:
         resultants = linearity.apply(resultants)
@@ -1224,7 +1224,8 @@ def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, rng=None,
 
     res = copy.deepcopy(model)
     res.data[m] = newimage
-    res.var_rnoise[m] = readvar
+    if hasattr(res, 'var_rnoise'):
+        res.var_rnoise[m] = readvar
     res.var_poisson[m] = poissonvar
     res.err[m] = np.sqrt(readvar + poissonvar)
     return res

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -108,7 +108,6 @@ import galsim
 from scipy import ndimage
 from . import parameters
 from . import log
-from astropy import units as u
 from . import cr
 
 from roman_datamodels.datamodels import ScienceRawModel
@@ -418,7 +417,7 @@ def make_asdf(resultants, dq=None, filepath=None, metadata=None, persistence=Non
     if metadata is not None:
         out['meta'].update(metadata)
     extras = dict()
-    out['data'][:, nborder:-nborder, nborder:-nborder] = resultants.value
+    out['data'][:, nborder:-nborder, nborder:-nborder] = resultants
     if dq is not None:
         extras['dq'] = np.zeros(out['data'].shape, dtype='i4')
         extras['dq'][:, nborder:-nborder, nborder:-nborder] = dq
@@ -490,36 +489,37 @@ def make_l1(counts, read_pattern,
     Parameters
     ----------
     counts : galsim.Image
-        total electrons delivered to each pixel
+        Total electrons delivered to each pixel
     read_pattern : int or list[list]
         MA table number or list of lists giving indices of reads entering each
         resultant.
-    read_noise : np.ndarray[ny, nx] (float) or float
-        Read noise entering into each read
-    pedestal_extra_noise : np.ndarray[ny, nx] (float) or float
-        Extra noise entering into each pixel (i.e., degenerate with pedestal)
-    rng : galsim.BaseDeviate
+    read_noise : np.ndarray[ny, nx] (float) or float, optional
+        Read noise in DN entering into each read
+    pedestal_extra_noise : np.ndarray[ny, nx] (float) or float, optional
+        Extra noise in DN entering into each pixel (i.e., degenerate with pedestal)
+    rng : galsim.BaseDeviate, optional
         Random number generator to use
-    seed : int
+    seed : int, optional
         Seed for populating RNG.  Only used if rng is None.
-    gain : float or np.ndarray[float]
-        Gain (electrons / DN) for converting DN to electrons
-    inv_linearity : romanisim.nonlinearity.NL or None
+    gain : float or np.ndarray[float], optional
+        Gain in electron/DN for converting electrons to DN
+    inv_linearity : romanisim.nonlinearity.NL, optional
         Object describing the inverse non-linearity corrections.
-    crparam : dict
+    crparam : dict, optional
         Keyword arguments to romanisim.cr.simulate_crs.  If None, no
         cosmic rays are simulated.
-    persistence : romanisim.persistence.Persistence
+    persistence : romanisim.persistence.Persistence, optional
         Persistence instance describing persistence-affected pixels
-    tstart : astropy.time.Time
-        time of exposure start
+    tstart : astropy.time.Time, optional
+        Time of exposure start
+    saturation : float, optional
+        Saturation level in DN
 
     Returns
     -------
-    l1, dq
-    l1: np.ndarray[n_resultant, ny, nx]
-        resultants image array including systematic effects
-    dq: np.ndarray[n_resultant, ny, nx]
+    l1 : np.ndarray[n_resultant, ny, nx]
+        Resultants image array in DN including systematic effects
+    dq : np.ndarray[n_resultant, ny, nx]
         DQ array marking saturated pixels and cosmic rays
     """
 
@@ -534,23 +534,15 @@ def make_l1(counts, read_pattern,
 
     add_ipc(resultants)
 
-    if not isinstance(resultants, u.Quantity):
-        resultants *= u.electron
-
+    # resultants are in electrons
     if gain is None:
         gain = parameters.reference_data['gain']
-    if gain is not None and not isinstance(gain, u.Quantity):
-        gain = gain * u.electron / u.DN
-        log.warning('Making up units for gain.')
 
-    resultants /= gain
+    # Convert electrons to DN
+    resultants /= gain  # gain is electron/DN
 
-    if read_noise is not None and not isinstance(read_noise, u.Quantity):
-        read_noise = read_noise * u.DN
-        log.warning('Making up units for read noise.')
-
-    # resultants are now in counts.
-    # read noise is in counts.
+    # resultants are now in DN
+    # read noise is in DN
     log.info('Adding read noise...')
     resultants = add_read_noise_to_resultants(
         resultants, tij, rng=rng, seed=seed,
@@ -570,7 +562,7 @@ def make_l1(counts, read_pattern,
     # it's not actually clear to me what the right thing to do
     # is in detail.
     # let things go a little higher than saturation
-    resultants = np.clip(resultants, 0 * u.DN, saturation * 1.1)
+    resultants = np.clip(resultants, 0, saturation * 1.1)  # DN
     m = resultants >= saturation
     dq[m] |= parameters.dqbits['saturated']
 

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -572,8 +572,7 @@ def make_l1(counts, read_pattern,
 
     if saturation is None:
         saturation = parameters.reference_data['saturation']
-    if not isinstance(saturation, u.Quantity):
-        saturation = saturation * u.DN
+    # saturation in DN
 
     # this maybe should be better applied at read time?
     # it's not actually clear to me what the right thing to do

--- a/romanisim/l3.py
+++ b/romanisim/l3.py
@@ -412,7 +412,7 @@ def simulate(shape, wcs, efftimes, filter_name, catalog, nexposures=1,
         # note that we are ignoring all of the individual reads, which also
         # contribute to reducing the effective read noise.  Pass --effreadnoise
         # if you want to do better than this!
-        effreadnoise = effreadnoise.to(u.electron).value * etomjysr
+        effreadnoise = effreadnoise * etomjysr  # electron -> MJy/sr
         # converting to MJy/sr units
     else:
         effreadnoise = 0

--- a/romanisim/parameters.py
+++ b/romanisim/parameters.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 from astropy.time import Time
-from astropy import units as u
 
 # If left unspecified anywhere, define a date of simulation.
 default_date = Time('2026-01-01T00:00:00', format='isot')
@@ -228,14 +227,14 @@ default_mosaic_parameters_dictionary = {
 }
 
 reference_data = {
-    "dark": 0.01 * u.electron / u.s,
+    "dark": 0.01,  # electron/s
     "distortion": None,
     "flat": None,
-    "gain": 2 * u.electron / u.DN,
+    "gain": 2,  # electron/DN
     "inverselinearity": None,
     "linearity": None,
-    "readnoise": 5.0 * u.DN,
-    "saturation": 55000 * u.DN,
+    "readnoise": 5.0,  # DN
+    "saturation": 55000,  # DN
 }
 
 nborder = 4  # number of border pixels used for reference pixels.
@@ -263,10 +262,10 @@ persistence = dict(A=0.017, x0=6.0e4, dx=5.0e4, alpha=0.045, gamma=1,
                    half_well=50000, ignorerate=0.01)
 
 # arbitrary constant to add to initial L1 image so that pixels aren't clipped at zero.
-pedestal = 5000 * u.DN
+pedestal = 5000  # DN
 
 # Addd this much extra noise as correlated extra noise in all resultants.
-pedestal_extra_noise = 4 * u.DN
+pedestal_extra_noise = 4  # DN
 
 dqbits = dict(saturated=2, jump_det=4, nonlinear=2**16, no_lin_corr=2**20)
 dq_do_not_use = dqbits['saturated'] | dqbits['jump_det']

--- a/romanisim/ramp.py
+++ b/romanisim/ramp.py
@@ -34,7 +34,6 @@ import numpy as np
 from . import parameters, l1
 import romanisim.ramp_fit_casertano
 from scipy import interpolate
-from astropy import units as u
 
 
 def read_pattern_to_tbar(read_pattern):
@@ -315,13 +314,9 @@ class RampFitInterpolator:
         """
         # clip points outside range to edges.
         fluxonreadvar = flux / read_noise**2
-        if isinstance(fluxonreadvar, u.Quantity):
-            unit = fluxonreadvar.unit
-        else:
-            unit = 1
         fluxonreadvar = np.clip(
-            fluxonreadvar, self.flux_on_readvar_pts[0] * unit,
-            self.flux_on_readvar_pts[-1] * unit)
+            fluxonreadvar, self.flux_on_readvar_pts[0],
+            self.flux_on_readvar_pts[-1])
 
         return self.ki_interpolator(fluxonreadvar).astype('f4')
 
@@ -343,13 +338,9 @@ class RampFitInterpolator:
         """
         # clip points outside range to edges.
         fluxonreadvar = flux / read_noise**2
-        if isinstance(fluxonreadvar, u.Quantity):
-            unit = fluxonreadvar.unit
-        else:
-            unit = 1
         fluxonreadvar = np.clip(
-            fluxonreadvar, self.flux_on_readvar_pts[0] * unit,
-            self.flux_on_readvar_pts[-1] * unit)
+            fluxonreadvar, self.flux_on_readvar_pts[0],
+            self.flux_on_readvar_pts[-1])
         var = self.var_interpolator(fluxonreadvar).astype('f4')
         read_noise = np.array(read_noise)
         read_noise = read_noise.reshape(
@@ -493,10 +484,6 @@ def fit_ramps_casertano(resultants, dq, read_noise, read_pattern):
         the covariance matrix of par, for each of three noise terms:
         the read noise, Poisson source noise, and total noise.
     """
-
-    resultants_unit = getattr(resultants, 'unit', None)
-    if resultants_unit is not None:
-        resultants = resultants.to(u.electron).value
 
     resultants = np.array(resultants).astype('f4')
 

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -77,12 +77,12 @@ def test_make_l2():
         resultants, read_pattern, gain=1, flat=1, darkrate=0)
     assert np.allclose(slopes, 0)
     resultants[:, :, :] = np.arange(4)[:, None, None]
-    resultants *= u.DN
-    gain = 1 * u.electron / u.DN
+    # resultants in DN, gain in electron/DN
+    gain = 1  # electron/DN
     slopes, readvar, poissonvar = image.make_l2(
         resultants, read_pattern,
         gain=gain, flat=1, darkrate=0)
-    assert np.allclose(slopes, 1 / parameters.read_time / 4 * u.DN / u.s)
+    assert np.allclose(slopes, 1 / parameters.read_time / 4)  # DN/s
     assert np.all(np.array(slopes.shape) == np.array(readvar.shape))
     assert np.all(np.array(slopes.shape) == np.array(poissonvar.shape))
     assert np.all(readvar >= 0)
@@ -568,7 +568,7 @@ def test_simulate():
     roughguess = roughguess * 140  # seconds of integration
     gain = parameters.reference_data['gain']
     assert np.abs(
-        np.log(np.mean(diff * gain).value / roughguess)) < 1
+        np.log(np.mean(diff * gain) / roughguess)) < 1
     # within a factor of e
     log.info('DMS224: added persistence to an image.')
 
@@ -686,8 +686,8 @@ def test_inject_source_into_image():
     assert np.all(im.data[-10:, -10:] == iminj.data[-10:, -10:])
 
     # Test that the amount of added flux makes sense
-    fluxeps = flux * romanisim.bandpass.get_abflux('F158', int(meta['instrument']['detector'][3:]))  # u.electron / u.s
-    assert np.abs(np.sum(iminj.data - im.data) * parameters.reference_data['gain'].value /
+    fluxeps = flux * romanisim.bandpass.get_abflux('F158', int(meta['instrument']['detector'][3:]))  # electron/s
+    assert np.abs(np.sum(iminj.data - im.data) * parameters.reference_data['gain'] /
                   fluxeps - 1) < 0.1
 
     # Create log entry and artifacts
@@ -757,7 +757,7 @@ def test_image_input(tmpdir):
     # did we get all the flux?
     totflux = np.sum(res[0].data - np.median(res[0].data))
     expectedflux = (romanisim.bandpass.get_abflux('F087', int(meta['instrument']['detector'][3:])) * np.sum(tab['F087'])
-                    / parameters.reference_data['gain'].value)
+                    / parameters.reference_data['gain'])
     assert np.abs(totflux / expectedflux - 1) < 0.1
 
     # are there sources where there should be?

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -16,7 +16,6 @@ from romanisim import l1, log, parameters, nonlinearity
 import galsim
 import galsim.roman
 import asdf
-from astropy import units as u
 import os
 
 

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -78,7 +78,7 @@ def test_apportion_counts_to_resultants():
         assert np.all(np.diff(resultants, axis=0) >= 0)
         assert np.all(resultants >= 0)
         assert np.all(resultants <= counts[None, :, :])
-        res2 = l1.add_read_noise_to_resultants(resultants.copy() * u.DN,
+        res2 = l1.add_read_noise_to_resultants(resultants.copy(),  # DN
                                                tij)
         res3 = l1.add_read_noise_to_resultants(resultants.copy(), tij,
                                                read_noise=read_noise)
@@ -256,7 +256,7 @@ def test_make_l1_and_asdf(tmp_path):
     galsim.roman.n_pix = 100
     for read_pattern in read_pattern_list:
         resultants, dq = l1.make_l1(galsim.Image(counts), read_pattern,
-                                    gain=1 * u.electron / u.DN)
+                                    gain=1)  # electron/DN
         assert resultants.shape[0] == len(read_pattern)
         assert resultants.shape[1] == counts.shape[0]
         assert resultants.shape[2] == counts.shape[1]
@@ -266,26 +266,26 @@ def test_make_l1_and_asdf(tmp_path):
         # we could look for non-zero correlations from the IPC to
         # check that that is working?  But that is slightly annoying.
         resultants, dq = l1.make_l1(galsim.Image(counts), read_pattern,
-                                    read_noise=0 * u.DN,
-                                    gain=1 * u.electron / u.DN)
+                                    read_noise=0,  # DN
+                                    gain=1)  # electron/DN
         assert np.all(resultants - parameters.pedestal
-                      <= np.max(counts[None, ...] * u.DN))
+                      <= np.max(counts[None, ...]))  # DN
         # because of IPC, one can't require that each pixel is smaller
         # than the number of counts
-        assert np.all(resultants >= 0 * u.DN)
-        assert np.all(np.diff(resultants, axis=0) >= 0 * u.DN)
+        assert np.all(resultants >= 0)  # DN
+        assert np.all(np.diff(resultants, axis=0) >= 0)  # DN
         res_forasdf, extras = l1.make_asdf(
             resultants, filepath=tmp_path / 'tmp.asdf')
         af = asdf.AsdfFile()
         af.tree = {'roman': res_forasdf}
         af.validate()
         resultants, dq = l1.make_l1(galsim.Image(np.full((100, 100), 10**7)),
-                                    read_pattern, gain=1 * u.electron / u.DN,
-                                    saturation=10**6 * u.DN)
+                                    read_pattern, gain=1,  # electron/DN
+                                    saturation=10**6)  # DN
         assert np.all((dq[-1] & parameters.dqbits['saturated']) != 0)
         resultants, dq = l1.make_l1(galsim.Image(np.zeros((100, 100))),
-                                    read_pattern, gain=1 * u.electron / u.DN,
-                                    read_noise=0 * u.DN, crparam=dict())
+                                    read_pattern, gain=1,  # electron/DN
+                                    read_noise=0, crparam=dict())  # DN
         assert np.all((resultants[0] - parameters.pedestal == 0)
                       | ((dq[0] & parameters.dqbits['jump_det']) != 0))
     log.info('DMS227: successfully made an L1 file that validates.')

--- a/romanisim/tests/test_linear.py
+++ b/romanisim/tests/test_linear.py
@@ -20,7 +20,7 @@ def test_linear_apply():
     coeffs = np.array([0, 0.994, 3.0e-5, 5.0e-10, 7.0e-15], dtype='f4')
     lin_coeffs = np.tile(coeffs[:, np.newaxis, np.newaxis], (1, 100, 100))
     lin_coeffs[:, 0:50, :] *= 2.0
-    gain = 4.0 * u.electron / u.DN
+    gain = 4.0  # electron/DN
     counts[0, 0] = counts[0, 99] = counts[99, 0] = counts[99, 99] = 11.0
 
     linearity = nonlinearity.NL(lin_coeffs, gain=gain)
@@ -43,7 +43,7 @@ def test_repair_coeffs():
     lin_coeffs[:, 1, 1] *= 0
     lin_coeffs[2, 22, 22] = np.nan
 
-    gain = 4.0 * u.electron / u.DN
+    gain = 4.0  # electron/DN
 
     linearity = nonlinearity.NL(lin_coeffs, gain=gain)
 
@@ -65,17 +65,15 @@ def test_electrons():
     coeffs = np.array([0, 0.994, 3.0e-5, 5.0e-10, 7.0e-15], dtype='f4')
     lin_coeffs = np.tile(coeffs[:, np.newaxis, np.newaxis], (1, 100, 100))
     lin_coeffs[:, 0:50, :] *= 2.0
-    gain = 4.0 * u.electron / u.DN
+    gain = 4.0  # electron/DN
 
     linearity = nonlinearity.NL(lin_coeffs, gain=gain)
 
-    res = linearity.apply(counts)
+    res = linearity.apply(counts)  # DN
 
-    res_elec = linearity.apply(gain * counts, electrons=True)
+    res_elec = linearity.apply(gain * counts, electrons=True)  # electrons
 
     assert np.all(res_elec[:] == gain * res[:])
-    assert res_elec.unit == u.electron / u.DN
-    assert not hasattr(res, "unit")
 
 
 def test_reverse():
@@ -85,7 +83,7 @@ def test_reverse():
 
     lin_coeffs[:, 0:50, :] *= 2.0
     rev_lin_coeffs = lin_coeffs[::-1, ...]
-    gain = 4.0 * u.electron / u.DN
+    gain = 4.0  # electron/DN
 
     linearity = nonlinearity.NL(lin_coeffs, gain=gain)
     rev_linearity = nonlinearity.NL(rev_lin_coeffs, gain=gain)

--- a/romanisim/tests/test_linear.py
+++ b/romanisim/tests/test_linear.py
@@ -6,7 +6,6 @@ Routines tested:
 - apply
 """
 import numpy as np
-from astropy import units as u
 from astropy import stats
 import crds
 

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -528,12 +528,11 @@ def update_photom_keywords(im, gain=None):
     ----------
     im : roman_datamodels.ImageModel
         Image whose metadata should be updated with photometry keywords
-    gain : float, Quantity, array
-        Gain image to use
+    gain : float or np.ndarray, optional
+        Gain in electron/DN (scalar or image)
     """
     gain = (np.median(gain)
             if gain is not None else parameters.reference_data['gain'])
-    gain = gain.value if isinstance(gain, u.Quantity) else gain
     if 'wcs' in im['meta']:
         wcs = im['meta']['wcs']
         cenpix = (im.data.shape[0] // 2, im.data.shape[1] // 2)


### PR DESCRIPTION
This PR removes astropy units usage for electron, DN, and related units (electron/s, DN/s, electron/DN gain) from romanisim codebase. 

romanisim originally did not use these units, but we at some point added them to the Roman reference files and romancal.  We later removed them.  Since they are no longer in the reference files it now makes sense to remove them again in romanisim.

This PR is mostly unit removals and the removal of related code that tries to correctly handle cases when units are or are not sent into a function.  I've tried to add more information and docstrings tracking intended units to partially make up for the removed programmatic unit requirements.  I've made corresponding updates to the tests.