### PR TITLE
[SCSB-225] migrate `[tool.pytest.ini_options]` to native TOML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ docs = [
 ]
 test = [
   "ci-watson >=0.3.0",
-  "pytest >=4.6.0, <=8.0",
+  "pytest>=9.0",
   "pytest-openfiles >=0.5.0",
   "pytest-doctestplus >=0.10.0",
   "pytest-cov >=2.9.0",
@@ -74,8 +74,8 @@ zip-safe = false
 [tool.setuptools.packages.find]
 exclude = ["examples"]
 
-[tool.pytest.ini_options]
-minversion = "4.6"
+[tool.pytest]
+minversion = "9.0"
 norecursedirs = ["docs/_build", "docs/exts", "scripts", "build", ".tox"]
 doctest_plus = "enabled"
 doctest_rst = "enabled"


### PR DESCRIPTION
Resolves [SCSB-225](https://jira.stsci.edu/browse/SCSB-225)

Pytest 9.0 includes a native TOML table `[tool.pytest]`, which we should use instead of `[tool.pytest.ini_options]`