### PR TITLE
Support error as 16 bit float if roman_datamodels wants that

### DIFF
--- a/docs/romanisim/catalog.rst
+++ b/docs/romanisim/catalog.rst
@@ -64,3 +64,4 @@ The simulator allows for passage of a user-specified COSMOS file (one which must
 The simulator can also generate place Gaia stars at the appropriate locations using the ``make_gaia_stars`` method, in place of the random stars in ``make_stars``.  Note that these stars have fluxes exactly equal to the Gaia G band fluxes in all bands; i.e., no attempt is made to predict accurate colors of stars.
 
 .. automodapi:: romanisim.catalog
+.. automodapi:: romanisim.gaia

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -1071,7 +1071,8 @@ def make_asdf(slope, slopevar_rn, slopevar_poisson, metadata=None,
     out['var_poisson'] = slopevar_poisson
     out['var_rnoise'] = slopevar_rn
     out['var_flat'] = slopevar_rn * 0
-    out['err'] = np.sqrt(out['var_poisson'] + out['var_rnoise'] + out['var_flat'])
+    err = np.sqrt(out['var_poisson'] + out['var_rnoise'] + out['var_flat'])
+    out['err'] = err.astype(out['err'].dtype)
     out['amp33'] = np.zeros((n_groups, 4096, 128), dtype=out.amp33.dtype)
     for side in ('left', 'right', 'top', 'bottom'):
         if side in ('left', 'right'):

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -1070,18 +1070,19 @@ def make_asdf(slope, slopevar_rn, slopevar_poisson, metadata=None,
         out['dq'][:, :] = dq
 
     def assign_with_default_types(fielddict, out):
+        # assign fields with existing types, only if they're already
+        # present.
         for field in fielddict:
-            if out.get(field, None) is not None:
-                dtype = out[field].dtype
-            else:
-                dtype = fielddict[field][1]
-            out[field] = fielddict[field][0].astype(dtype)
+            if out.get(field, None) is None:
+                continue
+            dtype = out[field].dtype
+            out[field] = fielddict[field].astype(dtype)
 
     fielddict = dict(
-        var_poisson=(slopevar_poisson, np.float16),
-        var_rnoise=(slopevar_rn, np.float16),
-        var_flat=(slopevar_rn * 0, np.float16),
-        err=(np.sqrt(slopevar_poisson + slopevar_rn), np.float16),
+        var_poisson=slopevar_poisson,
+        var_rnoise=slopevar_rn,
+        var_flat=slopevar_rn * 0,
+        err=np.sqrt(slopevar_poisson + slopevar_rn),
     )
     assign_with_default_types(fielddict, out)
 


### PR DESCRIPTION
For B21 the L2 data model will have an 'error' and 'var_poisson' fields that are float16 rather than a float32.  We try to support that here.  Likewise we try to only fill in the 'required' fields in the L1 / L2 files by testing to see whether roman_datamodels has made those fields.  The goal is to produce products that are closer to what the pipeline will produce in terms of optional fields.