### PR TITLE
Update docs to explain that we support only python <= 3.13

### DIFF
--- a/docs/romanisim/install.rst
+++ b/docs/romanisim/install.rst
@@ -10,6 +10,8 @@ and you should be largely set!
 The most frequently encountered difficulty installing romanisim is
 when GalSim is unable to find FFTW.  If your system does not have the
 FFTW library, these should be installed before romanisim and GalSim.
+Only python <= 3.13 is support at present due to the lack of a Python 3.14
+wheel for galsim.
 
 Another problematic dependency is `STPSF
 <https://stpsf.readthedocs.io>`_, which requires data files to


### PR DESCRIPTION
This adds a short disclaimer to the docs to say that python 3.14 isn't supported.