### PR TITLE
Skip slow CRDS match test

### DIFF
--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -608,6 +608,7 @@ def test_make_test_catalog_and_images():
     assert len(res) > 0
 
 
+@pytest.mark.bigdata
 @pytest.mark.parametrize(
     "level",
     [


### PR DESCRIPTION
This disables the CRDS matching test by default because it takes 2/3 of all unit test time.