### PR TITLE
Improve Handling of APT-Driven Simulations

### DIFF
--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -886,6 +886,7 @@ def read_catalog(filename,
         else:
             meta = dict()
         nside = meta.get('nside', 128)
+        ext = meta.get('extension', 'fits')
 
         # Set parameters of Healpix
         hp = astropy_healpix.HEALPix(
@@ -901,7 +902,7 @@ def read_catalog(filename,
         cat = None
         for i, healpix_index in enumerate(hp_cone):
             log.info(f'Loading healpix catalog file {i + 1} of {len(hp_cone)}')
-            hp_filename = filename + f"/cat-{healpix_index}.fits"
+            hp_filename = filename + f"/cat-{healpix_index}.{ext}"
             if os.path.isfile(hp_filename):
                 hp_table = read_one_healpix(hp_filename, date, bandpasses, **kwargs)
                 if cat is None:

--- a/scripts/romanisim-make-stack
+++ b/scripts/romanisim-make-stack
@@ -210,9 +210,11 @@ def main():
                             line += f" --previous {previous_file_name[sca]}"
 
                 # Add image options for contents of pointing input file
+                # Subtract 60 deg from APT PA to convert from APT V3 PA
+                # to WFI_CEN PA
                 line += f" --bandpass {bandpass}"
                 line += f" --radec {entry['RA']} {entry['DEC']}"
-                line += f" --roll {entry['PA']}"
+                line += f" --roll {entry['PA'] - 60}"
                 line += f" --ma_table_number {ma_table_number}"
                 line += f" --catalog {args.cat_file_name}"
 


### PR DESCRIPTION
This PR includes two commits, one for each change:

1. In romanisim-make-stack, subtract 60 degrees from the position angle read from the APT simulator ECSV file. This fixes the fact that APT is reporting the PA of the telescope V3 axis, which is rotated 60 degrees with respect to the WFI_CEN aperture PA.
2. In catalog.py, add a new option to the meta.yaml file in catalog directories that allows one to change the file extension of the catalog files (formerly cat-{healpixel}.fits and now cat-{healpixel}.{ext} where ext is defined in the YAML file and must be compatible with astropy readers).