### PR TITLE
RCAL-1299: Support for Regression Testing

### DIFF
--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -352,6 +352,10 @@ def make_cosmos_galaxies(coord,
     source_pert = np.ones(len(sim_ids))
     source_pert += ((0.2) * rng_numpy.normal(size=len(sim_ids)))
 
+    # Sort bandpasses to preserve order
+    bandpasses = list(bandpasses)
+    bandpasses.sort()
+
     # Convert fluxes to maggies by converting to Jankskys and normalizing for zero-point
     for bandpass in bandpasses:
         # Perturb sources fluxes by 5% per bandwidth
@@ -859,7 +863,7 @@ def read_catalog(filename,
         Radius over which to search healpix for source file indicies
 
     Any additional keyword arguments provided will be passed to
-    `make_gaia_stars` if the `filename` argument is None or 
+    `make_gaia_stars` if the `filename` argument is None or
     `read_one_healpix` if `filename` is a directory of healpix catalogs.
 
     Returns

--- a/romanisim/catalog.py
+++ b/romanisim/catalog.py
@@ -32,7 +32,7 @@ F158_H_COEFF = 0.823395077391525
 F184_KS_COEFF = 0.3838145747397368
 
 # Bandpass filters
-BANDPASSES = set(romanisim.bandpass.galsim2roman_bandpass.values())
+BANDPASSES = list(romanisim.bandpass.galsim2roman_bandpass.values())
 
 
 @dataclasses.dataclass

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -930,13 +930,13 @@ def simulate(metadata, objlist,
     seed : int
         Seed for populating RNG.  Only used if rng is None.
     psf_keywords : dict
-        Keywords passed to the PSF generation routine. 
+        Keywords passed to the PSF generation routine.
         For STPSF, this dict can also include an "stpsf_options" dictionary to specify WFI object options (e.g. defocus, jitter).
     extra_counts : ndarray, galsim.Image (optional)
-        An additional array that just gets added into the counts image. 
-        Useful for wrapping idealized images into L1/L2 images + the 
+        An additional array that just gets added into the counts image.
+        Useful for wrapping idealized images into L1/L2 images + the
         Roman datamodel.
-    
+
     Returns
     -------
     image : roman_datamodels model
@@ -1150,8 +1150,8 @@ def make_asdf(slope, slopevar_rn, slopevar_poisson, metadata=None,
     return out, extras
 
 
-def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, rng=None,
-                           gain=None, psftype='epsf'):
+def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, seed=50,
+                           rng=None, gain=None, psftype='epsf'):
     """Inject sources into an L2 image.
 
     This routine allows sources to be injected into an existing L2 image.
@@ -1188,6 +1188,8 @@ def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, rng=None,
         y coordinates of catalog locations in image
     psf: galsim.gsobject.GSObject
         PSF to use
+    seed : int
+        Seed for populating RNG.  Only used if rng is None.
     rng: galsim.BaseDeviate
         galsim random number generator to use
     gain: float [electron / DN]
@@ -1201,7 +1203,7 @@ def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, rng=None,
         model with additional sources
     """
     if rng is None:
-        rng = galsim.UniformDeviate(123)
+        rng = galsim.UniformDeviate(seed)
 
     if x is None or y is None:
         x, y = model.meta.wcs.numerical_inverse(


### PR DESCRIPTION
The bandpasses were being stored in an unsorted fashion, which lead to random position in a random number generator. This caused inconsistent results from run to run with the same seed. This ticket rectifies that.