### PR TITLE
Fix decayed options to L3

### DIFF
--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -188,7 +188,8 @@ def create_catalog(metadata=None, catalog_name=None, bandpasses=['F087'],
     if metadata is not None:
         twcs = wcs.get_wcs(metadata, usecrds=usecrds, distortion=distortion)
 
-        if not isinstance(coord, coordinates.SkyCoord):
+        if (not isinstance(coord, coordinates.SkyCoord) and
+            not isinstance(coord, galsim.CelestialCoord)):
             coord = twcs.toWorld(galsim.PositionD(*coord))
 
     # Create catalog

--- a/scripts/romanisim-make-l3
+++ b/scripts/romanisim-make-l3
@@ -42,7 +42,7 @@ if __name__ == '__main__':
     parser.add_argument('--effreadnoise', type=float, default=None,
                         help='effective readnoise per pixel in MJy/sr.  If '
                         'None, a pessimistic estimate is computed.')
-    parser.add_argument('--nexposures', type=float, default=1,
+    parser.add_argument('--nexposures', type=int, default=1,
                         help='number of exposures on field.  Used only '
                         'to compute the effective read noise.')
     parser.add_argument('--rng_seed', type=int, default=None)


### PR DESCRIPTION
Jaclyn Jensen reports problems generating L3 images with romanisim.  This PR makes two fixes intended to improve this.

With this PR the following works and generates the following image:
```
romanisim-gaia-catalog 341.8 -58.4 2026-01-01 --radius 0.5 gaia.ecsv
romanisim-make-l3 --bandpass F106 --radec 341.8 -58.4 --npix 4088 --pixscalefrac 1.0 --exptime 642.0 --rng_seed 42 out.asdf gaia.ecsv --nexposures 100
```
<img width="630" height="587" alt="image" src="https://github.com/user-attachments/assets/c941c686-2b1d-49e2-86d9-05143dff347d" />
