### PR TITLE
increase roman_datamodels upper pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "crds >=13.0.2",
   "defusedxml >=0.5.0",
   "galsim >=2.5.1",
-  "roman_datamodels>=0.29.0,<0.31.0",
+  "roman_datamodels>=0.29.0",
   # "roman_datamodels @ git+https://github.com/spacetelescope/roman_datamodels.git",
   "gwcs >=0.25.0",
   "numpy >1.26",


### PR DESCRIPTION
Removes the roman_datamodels upper pin to allow romancal to add romanisim as a development dependency.

Testing in romancal here: https://github.com/spacetelescope/romancal/pull/2184
Once this PR is merged I'll update the romancal PR to point to main instead of this branch.