### PR TITLE
Skip flaky gaia test

### DIFF
--- a/romanisim/tests/test_catalog.py
+++ b/romanisim/tests/test_catalog.py
@@ -181,6 +181,7 @@ def test_cosmos_table_catalog(tmp_path):
         assert np.all(cat[bp] >= 0)
 
 
+@pytest.mark.skip(reason="flaky: depends on Gaia network service")
 def test_make_gaia_stars(tmp_path):
     """Test population of sources from Gaia catalog
     """


### PR DESCRIPTION
Since the Gaia server maintenance two weeks ago, the test_make_gaia_stars routine has started failing with a variety of errors.  This adds a skip to that test.