### PR TITLE
Update file generation scripts for integration with updated workflow

### DIFF
--- a/scripts/romancal_make_all_l1s.sh
+++ b/scripts/romancal_make_all_l1s.sh
@@ -19,11 +19,13 @@
 set -e
 
 # default image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf
+
 # # second image at a different location, different activity
 # romanisim-make-image --radec 270.00 66.01 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf
-# # default spectroscopic image
-# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
+
+# default spectroscopic image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
 # # truncated image
 # romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6
 # 
@@ -34,6 +36,6 @@ romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --ca
 # romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_{}_{bandpass}_uncal.asdf
 # # 16 resultant grism image
 # romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
-# 
-# # prism image
-# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:30:00 --rng_seed 8 --drop-extra-dq r0000301001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral PRISM
+
+# prism image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:30:00 --rng_seed 8 --drop-extra-dq r0000301001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral PRISM

--- a/scripts/romancal_make_all_l1s.sh
+++ b/scripts/romancal_make_all_l1s.sh
@@ -19,7 +19,7 @@
 set -e
 
 # default image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf
 # # second image at a different location, different activity
 # romanisim-make-image --radec 270.00 66.01 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf
 # # default spectroscopic image

--- a/scripts/romancal_make_all_l1s.sh
+++ b/scripts/romancal_make_all_l1s.sh
@@ -20,20 +20,20 @@ set -e
 
 # default image
 romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf
-# second image at a different location, different activity
-romanisim-make-image --radec 270.00 66.01 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf
-# default spectroscopic image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
-# truncated image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6
-
-# truncated grism image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 --pretend-spectral GRISM
-
-# 16 resultant image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_{}_{bandpass}_uncal.asdf
-# 16 resultant grism image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
-
-# prism image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:30:00 --rng_seed 8 --drop-extra-dq r0000301001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral PRISM
+# # second image at a different location, different activity
+# romanisim-make-image --radec 270.00 66.01 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf
+# # default spectroscopic image
+# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
+# # truncated image
+# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6
+# 
+# # truncated grism image
+# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 --pretend-spectral GRISM
+# 
+# # 16 resultant image
+# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_{}_{bandpass}_uncal.asdf
+# # 16 resultant grism image
+# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
+# 
+# # prism image
+# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:30:00 --rng_seed 8 --drop-extra-dq r0000301001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral PRISM

--- a/scripts/romancal_make_all_l1s.sh
+++ b/scripts/romancal_make_all_l1s.sh
@@ -15,27 +15,27 @@
 # The MA tables are also supposed to be slightly different (frame time is different?)
 # but I haven't done anything here.
 
-# stop on an error
-set -e
-
 # default image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf
-
-# # second image at a different location, different activity
-# romanisim-make-image --radec 270.00 66.01 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf
-
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf &
+# second image at a different location, different activity
+romanisim-make-image --radec 270.00 66.01 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf &
 # default spectroscopic image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
-# # truncated image
-# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6
-# 
-# # truncated grism image
-# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 --pretend-spectral GRISM
-# 
-# # 16 resultant image
-# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_{}_{bandpass}_uncal.asdf
-# # 16 resultant grism image
-# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM &
+# truncated image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 &
+
+# just do four at a time
+wait
+
+# truncated grism image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 --pretend-spectral GRISM &
+
+# 16 resultant image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_{}_{bandpass}_uncal.asdf &
+# 16 resultant grism image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM &
 
 # prism image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:30:00 --rng_seed 8 --drop-extra-dq r0000301001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral PRISM
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:30:00 --rng_seed 8 --drop-extra-dq r0000301001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral PRISM &
+
+wait

--- a/scripts/romancal_make_all_l1s.sh
+++ b/scripts/romancal_make_all_l1s.sh
@@ -16,26 +16,21 @@
 # but I haven't done anything here.
 
 # default image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf
 # second image at a different location, different activity
-romanisim-make-image --radec 270.00 66.01 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf &
+romanisim-make-image --radec 270.00 66.01 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf
 # default spectroscopic image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
 # truncated image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 &
-
-# just do four at a time
-wait
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6
 
 # truncated grism image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 --pretend-spectral GRISM &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 --pretend-spectral GRISM
 
 # 16 resultant image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_{}_{bandpass}_uncal.asdf &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_{}_{bandpass}_uncal.asdf
 # 16 resultant grism image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM &
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
 
 # prism image
-romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:30:00 --rng_seed 8 --drop-extra-dq r0000301001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral PRISM &
-
-wait
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:30:00 --rng_seed 8 --drop-extra-dq r0000301001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral PRISM

--- a/scripts/romancal_make_all_l1s.sh
+++ b/scripts/romancal_make_all_l1s.sh
@@ -15,6 +15,9 @@
 # The MA tables are also supposed to be slightly different (frame time is different?)
 # but I haven't done anything here.
 
+# stop on an error
+set -e
+
 # default image
 romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf
 # second image at a different location, different activity

--- a/scripts/romancal_make_l1_data_files.sh
+++ b/scripts/romancal_make_l1_data_files.sh
@@ -1,0 +1,41 @@
+# r0000101001001001001_0001_wfi01_f158 - default for most steps, ma table 109
+# r0000201001001001001_0001_wfi01_f158 - equivalent for spectroscopic data
+# r0000101001001001001_0002_wfi01_f158 - a second resample exposure, only cal step needed
+# r0000101001001001001_0003_wfi01_f158 - for ramp fitting; truncated image
+# r0000201001001001001_0003_wfi01_f158 - for ramp fitting; truncated spectroscopic
+#                                         we need only darkcurrent & ramp fit for these
+#
+# r0000101001001001001_0004_wfi01_f158 - 16 resultant file, ma table 110
+# r0000201001001001001_0004_wfi01_f158 - 16 resultant spectroscopic file, ma table 110
+
+# r0000301001001001001_0001_wfi01_f158 - prism image, ma table 109
+
+# note that the "spectroscopic" files are really imaging files where the only
+# thing that has been updated is the optical_element and exposure.type.
+# The MA tables are also supposed to be slightly different (frame time is different?)
+# but I haven't done anything here.
+
+# stop on an error
+set -e
+
+# default image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf
+
+# # second image at a different location, different activity
+# romanisim-make-image --radec 270.00 66.01 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf
+
+# default spectroscopic image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
+# # truncated image
+# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6
+# 
+# # truncated grism image
+# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 --pretend-spectral GRISM
+# 
+# # 16 resultant image
+# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_{}_{bandpass}_uncal.asdf
+# # 16 resultant grism image
+# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
+
+# prism image
+romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:30:00 --rng_seed 8 --drop-extra-dq r0000301001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral PRISM

--- a/scripts/romancal_make_l1_data_files.sh
+++ b/scripts/romancal_make_l1_data_files.sh
@@ -1,13 +1,5 @@
-# r0000101001001001001_0001_wfi01_f158 - default for most steps, ma table 109
+# r0000101001001001001_0001_wfi**_f158 - default for most steps, ma table 109
 # r0000201001001001001_0001_wfi01_f158 - equivalent for spectroscopic data
-# r0000101001001001001_0002_wfi01_f158 - a second resample exposure, only cal step needed
-# r0000101001001001001_0003_wfi01_f158 - for ramp fitting; truncated image
-# r0000201001001001001_0003_wfi01_f158 - for ramp fitting; truncated spectroscopic
-#                                         we need only darkcurrent & ramp fit for these
-#
-# r0000101001001001001_0004_wfi01_f158 - 16 resultant file, ma table 110
-# r0000201001001001001_0004_wfi01_f158 - 16 resultant spectroscopic file, ma table 110
-
 # r0000301001001001001_0001_wfi01_f158 - prism image, ma table 109
 
 # note that the "spectroscopic" files are really imaging files where the only
@@ -21,21 +13,8 @@ set -e
 # default image
 romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf
 
-# # second image at a different location, different activity
-# romanisim-make-image --radec 270.00 66.01 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:05:00 --rng_seed 2 --drop-extra-dq r0000101001001001001_0002_{}_{bandpass}_uncal.asdf
-
 # default spectroscopic image
 romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:10:00 --rng_seed 3 --drop-extra-dq r0000201001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
-# # truncated image
-# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:15:00 --rng_seed 4 --drop-extra-dq r0000101001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6
 # 
-# # truncated grism image
-# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:20:00 --rng_seed 5 --drop-extra-dq r0000201001001001001_0003_{}_{bandpass}_uncal.asdf --truncate 6 --pretend-spectral GRISM
-# 
-# # 16 resultant image
-# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:25:00 --rng_seed 6 --drop-extra-dq r0000101001001001001_0004_{}_{bandpass}_uncal.asdf
-# # 16 resultant grism image
-# romanisim-make-image --radec 270.00 66.00 --level 1 --sca -1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 110 --date 2027-06-01T00:30:00 --rng_seed 7 --drop-extra-dq r0000201001001001001_0004_{}_{bandpass}_uncal.asdf --pretend-spectral GRISM
-
 # prism image
 romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:30:00 --rng_seed 8 --drop-extra-dq r0000301001001001001_0001_{}_{bandpass}_uncal.asdf --pretend-spectral PRISM

--- a/scripts/romancal_make_regtest_l1s.sh
+++ b/scripts/romancal_make_regtest_l1s.sh
@@ -14,6 +14,9 @@
 # The MA tables are also supposed to be slightly different (frame time is different?)
 # but I haven't done anything here.
 
+# stop on an error
+set -e
+
 # default image
 romanisim-make-image --radec 270.00 66.00 --level 1 --sca 1 --bandpass F158 --catalog gaia-270-66-2027-06-01.ecsv --psftype stpsf --usecrds --ma_table_number 109 --date 2027-06-01T00:00:00 --rng_seed 1 --drop-extra-dq r0000101001001001001_0001_{}_{bandpass}_uncal.asdf
 # different location, different exposure


### PR DESCRIPTION
Add a new `scripts/romancal_make_l1_data_files.sh` script that generates the L1 files needed to generate:
- roman-data-workshop files
- L2 files for the MOC

These files are needed for every build and are currently manually generated. These scripts are compatible with an update to the regtest file generator:
https://github.com/spacetelescope/RegressionTests/pull/318
which will allow them to be:
- run regularly to monitor unexpected changes
- to be triggered via the usual system (the updated workflow now accepts script names)

with results written to artifactory (see https://github.com/spacetelescope/RegressionTests/pull/318 for more info).

I didn't use romancal_make_all_l1s.sh because:
- it generates many files that aren't needed for the above 2 use cases
- when run serially (needed without enabling CRDS file locking for the regtest runner) could result in error

I think it's worth considering a follow up PR to investigate running these in parallel (perhaps with gnu-parallel or just) to more efficiently use the multiple cores of the runner.

Finally I made a minor change to `scripts/romancal_make_regtest_l1s.sh` to make it stop on errors.