### PR TITLE
Skip too-large FFTs.

### DIFF
--- a/romanisim/__init__.py
+++ b/romanisim/__init__.py
@@ -13,6 +13,9 @@ rate images that are analagous to typical astronomical images.
 
 from importlib.metadata import version
 import logging
+import galsim
+
+galsim.errors.raise_fft_size_error = True  # we use this to skip expensive sources
 
 log = logging.getLogger(__name__)
 logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s',


### PR DESCRIPTION
galsim 2.8 changed what happens when galaxies need to be rendered that require too-large FFTs.  Before it triggered an error which we caught and turned into a warning, skipping the galaxy processing.  Now it triggers a warning but proceeds to render the requested, very expensive galaxy. This sets a galsim configuration parameter to restore the old behavior.

See https://github.com/GalSim-developers/GalSim/blob/v2.8.4/CHANGELOG.rst#api-changes for details on the galsim change.