### PR TITLE
wrap argument check for webbpsf and stpsf

### DIFF
--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -323,12 +323,18 @@ def simulate_image_file(args, metadata, cat, rng=None, persist=None, psf_keyword
         Keywords passed to the PSF generation routine. 
         For STPSF, this dict can also include an "stpsf_options" dictionary to specify WFI object options (e.g. defocus, jitter).
     """
-    if getattr(args, 'webbpsf', False) or getattr(args, 'stpsf', False):
+    try:
+        if getattr(args, 'webbpsf', False) or getattr(args, 'stpsf', False):
+            log.warning('Warning: webbpsf and stpsf arguments are deprecated, please use '
+                        '"--psftype stpsf" instead.')
+            del args.stpsf
+            del args.webbpsf
+            args.psftype = 'stpsf'
+    except AttributeError:
         log.warning('Warning: webbpsf and stpsf arguments are deprecated, please use '
-                    '"--psftype stpsf" instead.')
-        del args.stpsf
-        del args.webbpsf
+                        '"--psftype stpsf" instead. Setting psftype to stpsf.')
         args.psftype = 'stpsf'
+        
 
     filename = format_filename(args.filename, args.sca, bandpass=args.bandpass,
                                pretend_spectral=args.pretend_spectral)


### PR DESCRIPTION
In an environment with 0.13.0 installed, with stpsf installed, when running it's raises an error:

`AttributeError: ‘Namespace’ object has no attribute ‘webbpsf’`

Wrapping the block that checks for webbpsf and stpsf in the args fixes the issue. 

Included is an example fix, you may decide to do something else if you also can replicate. 

```
2026-03-17 16:14:11 WARNING  Warning: webbpsf and stpsf arguments are deprecated, please use “--psftype stpsf” instead.
Traceback (most recent call last):
  File “/home/kessler/romanisim/./romanisim_snpit.py”, line 689, in <module>
    run_sim(args, full_cat, sca, band_soc, mjd)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File “/home/kessler/romanisim/./romanisim_snpit.py”, line 413, in run_sim
    ris.simulate_image_file(args, metadata, full_cat, rng, persist)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File “/home/kessler/envs/conda/snpit411/lib/python3.14/site-packages/romanisim/ris_make_utils.py”, line 329, in simulate_image_file
    del args.webbpsf
        ^^^^^^^^^^^^
AttributeError: ‘Namespace’ object has no attribute ‘webbpsf’
```