### PR TITLE
Support specifying nexposures.

### DIFF
--- a/romanisim/ris_make_utils.py
+++ b/romanisim/ris_make_utils.py
@@ -1,6 +1,7 @@
 """Miscellaneous utility routines for the simulation file maker scripts.
 """
 
+import ast
 from copy import deepcopy
 import os
 import pathlib
@@ -47,6 +48,48 @@ def merge_nested_dicts(dict1, dict2):
             merge_nested_dicts(dict1[key], value)
         else:
             dict1[key] = value
+
+
+def add_meta_args(parser):
+    """Add a --meta argument to an argparse parser.
+
+    The --meta argument allows setting arbitrary metadata fields using
+    dot-notation keys and auto-typed values.  It may be specified multiple
+    times.  See apply_meta_args for details on value coercion.
+    """
+    parser.add_argument(
+        '--meta', action='append', default=None, metavar='KEY=VALUE',
+        help=('Set a metadata field using dot-notation KEY and VALUE. '
+              'Can be specified multiple times. Integers, floats, '
+              'booleans, and None are auto-detected; anything else is '
+              'treated as a string. '
+              'Example: --meta visit.nexposures=4 '
+              '--meta visit.visit_type=GENERIC'))
+
+
+def apply_meta_args(args, metadata):
+    """Apply --meta overrides from parsed args to a metadata dict.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed arguments; must have a ``meta`` attribute (list or None).
+    metadata : dict
+        Metadata dict to update in-place.
+    """
+    if args.meta is None:
+        return
+    for item in args.meta:
+        key, _, value = item.partition('=')
+        try:
+            value = ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            pass
+        parts = key.split('.')
+        d = metadata
+        for part in parts[:-1]:
+            d = d.setdefault(part, {})
+        d[parts[-1]] = value
 
 
 def set_metadata(meta=None, date=None, bandpass='F087', sca=7,

--- a/romanisim/tests/test_ris_make_utils.py
+++ b/romanisim/tests/test_ris_make_utils.py
@@ -3,6 +3,7 @@ Routines tested:
 * set_metadata
 * create_catalog
 * simulate_image_file
+* add_meta_args / apply_meta_args
 """
 
 import types
@@ -60,6 +61,30 @@ def test_parse_filename():
     assert obs is not None
     assert obs['program'] == 99999
     assert obs['pass'] == 1
+
+
+def test_apply_meta_args():
+    import argparse
+    meta = ris_make_utils.set_metadata()
+
+    # integer coercion and nested key creation
+    args = argparse.Namespace(meta=['visit.nexposures=4'])
+    ris_make_utils.apply_meta_args(args, meta)
+    assert meta['visit']['nexposures'] == 4
+    assert isinstance(meta['visit']['nexposures'], int)
+
+    # string fallback and multiple overrides
+    args = argparse.Namespace(meta=['visit.visit_type=GENERIC',
+                                    'visit.nexposures=2'])
+    ris_make_utils.apply_meta_args(args, meta)
+    assert meta['visit']['visit_type'] == 'GENERIC'
+    assert meta['visit']['nexposures'] == 2
+
+    # None arg is a no-op
+    original = meta['visit']['nexposures']
+    args = argparse.Namespace(meta=None)
+    ris_make_utils.apply_meta_args(args, meta)
+    assert meta['visit']['nexposures'] == original
 
 
 def test_format_filename():

--- a/scripts/romanisim-make-image
+++ b/scripts/romanisim-make-image
@@ -38,6 +38,8 @@ def go(args):
         usecrds=args.usecrds,
         truncate=args.truncate, scale_factor=args.scale_factor)
 
+    ris.apply_meta_args(args, metadata)
+
     if args.radec is not None:
         coord = SkyCoord(ra=args.radec[0] * u.deg, dec=args.radec[1] * u.deg,
                          frame='icrs')
@@ -131,6 +133,7 @@ if __name__ == '__main__':
                         help=('Do not store the optional simulated dq array.'))
     parser.add_argument('--scale-factor', type=float, default=-1.,
                         help=('Velocity aberration-induced scale factor. If negative, use given time to calculated based on orbit ephemeris.'))
+    ris.add_meta_args(parser)
     parser.add_argument('--extra-counts', type=str, default=None, nargs='+', help=(
         'An optional FITS file to read to get an array of counts to add into the simulated image. '
         'Useful for wrapping idealized images. '

--- a/scripts/romanisim-make-l3
+++ b/scripts/romanisim-make-l3
@@ -49,6 +49,7 @@ if __name__ == '__main__':
     parser.add_argument('--psftype', type=str, default='galsim',
                         choices=['epsf', 'galsim', 'stpsf'],
                         help='Type of PSF generator to use.')
+    ris.add_meta_args(parser)
 
     args = parser.parse_args()
 
@@ -69,6 +70,7 @@ if __name__ == '__main__':
         metadata['coadd_info']['time_mean'] = parameters.default_date
 
     metadata['filename'] = os.path.basename(args.filename)
+    ris.apply_meta_args(args, metadata)
 
     cat = ris.create_catalog(metadata=metadata, catalog_name=args.catalog,
                             bandpasses=[args.bandpass], coord=center, radius=args.npix)

--- a/scripts/romanisim-make-stack
+++ b/scripts/romanisim-make-stack
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import argparse
+from collections import Counter
 from copy import deepcopy
 import yaml
 from astropy.coordinates import SkyCoord
@@ -134,6 +135,11 @@ def main():
     # Open csv table pointing file
     pointings = Table.read(args.pointing_file_name, comment="#", delimiter=" ")
 
+    # Count exposures per visit for nexposures metadata
+    visit_counts = Counter(
+        (e['PLAN'], e['PASS'], e['SEGMENT'], e['OBSERVATION'], e['VISIT'])
+        for e in pointings)
+
     # If creating a script, create files
     if args.make_script:
         # Create script file
@@ -174,6 +180,7 @@ def main():
         plan, passno, segment, observation, visit, exposure = (
             entry['PLAN'], entry['PASS'], entry['SEGMENT'],
             entry['OBSERVATION'], entry['VISIT'], entry['EXPOSURE'])
+        nexposures = visit_counts[(plan, passno, segment, observation, visit)]
         ma_table_number = int(entry['MA_TABLE_NUMBER'])
         bandpass = entry['BANDPASS']
         if args.force_ma_table_number > 0:
@@ -217,6 +224,7 @@ def main():
                 line += f" --roll {entry['PA'] - 60}"
                 line += f" --ma_table_number {ma_table_number}"
                 line += f" --catalog {args.cat_file_name}"
+                line += f" --meta visit.nexposures={nexposures}"
 
                 # Debug print line
                 log.debug(f'line = {line}')
@@ -241,6 +249,7 @@ def main():
                                             usecrds=args.usecrds)
                 if apt_metadata:
                     util.merge_dicts(metadata, apt_metadata)
+                metadata.setdefault('visit', {})['nexposures'] = nexposures
 
                 # If selected, apply persistence
                 if args.persistence and entry_idx > 0:


### PR DESCRIPTION
This PR adds functionality to romanisim-make-image and romanisim-make-l3 to allow metadata keywords to be specified on the command line.  It then uses that functionality in romanisim-make-stack to determine the correct number of exposures entering each visit for an APT-generated program.

The mechanism used is that romanisim-make-image and romanisim-make-l3 gain a new --meta argument that takes arguments like visit.nexposures=4.  The visit.nexposures=4 string is parsed to interpret this as a metadata keyword and a value for that keyword.  This will fail if we have any weird metadata that has, for example, '=' in the name, but I think it will handle all existing cases in a reasonable way.

romanisim-make-stack computes the number of exposures in each visit by looping through the CSV file and explicitly counting each combination of (plan, pass, segment, observation, visit), and then adds --meta visit.nexposures=N to each  line of the output commands file.