### PR TITLE
Support more WCS types

### DIFF
--- a/romanisim/bandpass.py
+++ b/romanisim/bandpass.py
@@ -205,7 +205,7 @@ def etomjysr(bandpass, sca):
     Returns
     -------
     float
-        the factor F such that MJy / sr = F * DN/s
+        the factor F such that MJy / sr = F * e/s
     """
 
     abflux = get_abflux(bandpass, sca)  # e/s corresponding to 3631 Jy

--- a/romanisim/wcs.py
+++ b/romanisim/wcs.py
@@ -421,9 +421,15 @@ def convert_wcs_to_gwcs(wcs):
     """
     if isinstance(wcs, GWCS):
         return wcs.wcs
+    elif isinstance(wcs, gwcs.WCS):
+        return wcs
     else:
-        # make a gwcs WCS from a galsim.roman WCS
-        return wcs_from_fits_header(wcs.header.header)
+        if hasattr(wcs, 'header'):
+            # get fits header from galsim.roman WCS
+            header = wcs.header.header
+        else:
+            header = wcs
+        return wcs_from_fits_header(header)
 
 
 def get_mosaic_wcs(mosaic, shape=None, xpos=None, ypos=None, coord=None):


### PR DESCRIPTION
Folks doing simulations outside romanisim may want to use WCSes other than the romanisim GWCS, gwcs, or galsim.roman.WCS.  This adds support for a generic FITS header.