### PR TITLE
Fix readnoise pixfrac scaling

### DIFF
--- a/romanisim/l3.py
+++ b/romanisim/l3.py
@@ -398,9 +398,10 @@ def simulate(shape, wcs, efftimes, filter_name, catalog, nexposures=1,
     # Set effective read noise
     if effreadnoise is None:
         readnoise = np.median(romanisim.parameters.reference_data['readnoise'])
+        # read noise in DN
         gain = np.median(romanisim.parameters.reference_data['gain'])
         effreadnoise = (
-            np.sqrt(2) * readnoise * gain)
+            np.sqrt(2) * readnoise * gain)  # electron, difference of two reads
         # sqrt(2) from subtracting one read from another
         effreadnoise /= (np.median(efftimes * pixscalefrac ** 2) / nexposures)
         # divided by the typical exposure length
@@ -412,10 +413,10 @@ def simulate(shape, wcs, efftimes, filter_name, catalog, nexposures=1,
         # note that we are ignoring all of the individual reads, which also
         # contribute to reducing the effective read noise.  Pass --effreadnoise
         # if you want to do better than this!
-        effreadnoise = effreadnoise * etomjysr  # electron -> MJy/sr
+        effreadnoise = effreadnoise * etomjysr * pixscalefrac ** 2  # electron -> MJy/sr
+        # factor of pixfrac ** 2 because etomjysr is per L3 pixel, but
+        # this effreadnoise calculation is per native pixel
         # converting to MJy/sr units
-    else:
-        effreadnoise = 0
 
     chromatic = False
     if (len(catalog) > 0 and not isinstance(catalog, astropy.table.Table)
@@ -481,7 +482,7 @@ def simulate_cps(image, filter_name, efftimes, objlist=None, psf=None,
                  xpos=None, ypos=None, coord=None, sky=0, bandpass=None,
                  effreadnoise=None, maggytoes=None, etomjysr=None,
                  rng=None, seed=None, ignore_distant_sources=10,):
-    """Simulate average MegaJanskies per steradian in a single SCA.
+    """Simulate average MJy/sr in a single SCA.
 
     Parameters
     ----------
@@ -507,10 +508,10 @@ def simulate_cps(image, filter_name, efftimes, objlist=None, psf=None,
     effreadnoise : float
         Effective read noise for mosaic (MJy / sr)
     maggytoes: float
-        Factor to convert electrons to MJy / sr; one maggy makes
+        Factor to convert e/s to MJy / sr; one maggy makes
         this many e/s.
     etomjysr : float
-        Factor to convert electron to MJy/sr;  one e/s/pix corresponds
+        Factor to convert e/s to MJy / sr; one e/s/coadd pix corresponds
         to this MJy/sr.
     rng : galsim.BaseDeviate
         random number generator

--- a/romanisim/l3.py
+++ b/romanisim/l3.py
@@ -744,6 +744,9 @@ def add_more_metadata(metadata, efftimes, filter_name, wcs, shape, nexposures):
         meantime - maxtime / 24 / 60 / 60 / 2, format='mjd')
     metadata['coadd_info']['time_last'] = Time(
         meantime + maxtime / 24 / 60 / 60 / 2, format='mjd')
+    for field_name in ['time_first', 'time_last']:
+        metadata['coadd_info'][field_name] = Time(
+            metadata['coadd_info'][field_name].isot)
     metadata['coadd_info']['max_exposure_time'] = maxtime
     metadata['coadd_info']['exposure_time'] = meanexptime
     for step in ['flux', 'outlier_detection', 'skymatch', 'resample']:

--- a/romanisim/tests/test_l3.py
+++ b/romanisim/tests/test_l3.py
@@ -532,7 +532,7 @@ def test_scaling():
     twcs1 = romanisim.wcs.create_tangent_plane_gwcs(
         (npix / 2, npix / 2), pscale, coord)
     twcs2 = romanisim.wcs.create_tangent_plane_gwcs(
-        (npix / 2, npix / 2), pscale / 2, coord)
+        (npix, npix), pscale / 2, coord)
 
     im1, extras1 = l3.simulate(
         (npix, npix), twcs1, exptime, imdict['filter_name'],
@@ -600,3 +600,24 @@ def test_scaling():
 
     # these all match to a few percent; worst case in initial test run
     # was err3fracdiff of 0.039.
+
+    # test read noise scaling
+    im1, extras1 = l3.simulate(
+        (npix, npix), twcs1, exptime, imdict['filter_name'],
+        imdict['tabcatalog'], seed=rng_seed, effreadnoise=None, sky=0)
+
+    # half pixel scale
+    im2, extras2 = l3.simulate(
+        (npix * 2, npix * 2), twcs2, exptime, imdict['filter_name'],
+        imdict['tabcatalog'], seed=rng_seed, effreadnoise=None, sky=0)
+
+    for im in [im1, im2]:
+        assert np.abs(mad_std(im1.data) / np.median(im1.err) - 1) < 0.1
+        assert np.abs(np.median(im1.err) /
+                      np.median(np.sqrt(im1.var_rnoise)) - 1) < 0.1
+    assert np.abs(np.median(im2.err) / np.median(im1.err) / 4 - 1) < 0.1
+    # 2x finer sampling -> 4x higher read noise in per-unit-time units
+    # because constant read noise is divided by 4x smaller exposure time
+    # the 2x finer sampling effectively means that you need to take the
+    # four exposures and interleave them, each using 1/4 of the exposure
+    # time


### PR DESCRIPTION
Nikhil and Greg's investigations of the romanisim L3 files indicated that they were not as deep as they should be.  The root cause is that the read noise scaling with the pixel scale fraction was missing a factor of the square of the pixel scale fraction.

The default read noise computation uses the read noise per read and imagines that the total read noise is just sqrt(2) times the per-read read noise, a pessimistic assumption.  It then converts that to electrons / s using the total exposure time times the square of the pixscalefrac, reasoning that the total exposure time needs to be split up among pixscalefrac ** 2 output pixels.  The result is then converted to MJy / sr units for use downstream.

The final conversion to MJy / sr units assumed that we were starting with e / s / coadd pixel units, but the computation had been done assuming e / s / native pixel units, introducing a spurious factor of the pixscalefrac squared.  This PR fixes that issue.

It also fixes an unrelated error where the effective read noise was zeroed if an explicit value was sent by the user, makes some mild documentation updates, and adds a test of the read noise scaling with pixel scale fraction.

Closes https://github.com/spacetelescope/romanisim/issues/349 .