### PR TITLE
[SCSB-237] build Stable ABI3 wheels with `Py_LIMITED_API`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,26 +1,71 @@
 name: build
 
 on:
+  pull_request:
   release:
     types: [released]
-  pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   build:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@2835f0cacddf3f8de198db9afdb5354a5cebe0ef # v2.6.3
-    with:
-      env: |
-        FFTW_DIR: /opt/homebrew/opt/fftw/lib/
-      targets: |
-        # Linux wheels
-        - cp3*[!t]-manylinux_x86_64
-        # MacOS wheels
-        - cp3*[!t]-macosx_x86_64
-        # MacOS arm64 wheels
-        - cp3*[!t]-macosx_arm64
-      sdist: true
-      test_command: python -c "from romanisim import ramp_fit_casertano"
-      upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
-    secrets:
-      pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3"
+      - if: ${{ runner.os == 'Linux' }}
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: all
+      - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        with:
+          package-dir: ./
+          output-dir: dist/
+      - run: pip install build
+      - run: python -m build --sdist
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist-${{ runner.os }}-${{ runner.arch }}
+          path: ./dist/
+  publish:
+    if: (github.event_name == 'release') && (github.event.action == 'released')
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+    # To add required reviewers before deployment,
+    # edit the protection rules in GitHub Settings:
+    # Settings > Environments > pypi > Add required reviewers
+    environment:
+      name: pypi
+      url: https://pypi.org/p/romanisim
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: dist*
+          path: dist/
+          merge-multiple: true
+      - uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-path: "dist/*"
+      # To upload to PyPI without a token, add this workflow file as a Trusted Publisher in the project settings on the PyPI website
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,4 +125,4 @@ before-all = "brew install eigen fftw"
 FFTW_DIR = "/opt/homebrew/opt/fftw/lib/"
 
 [tool.cibuildwheel.linux]
-before-all = "yum install -y fftw-devel"
+before-all = "yum install -y fftw-devel || apk add fftw"  # manylinux is AlmaLinux; musllinux is Alpine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,4 +119,10 @@ skip = ["cp314t-*"]  # explicitly skip free-threaded builds
 test-command = "python -c 'from romanisim import ramp_fit_casertano; import galsim; galsim.fft.fft2(np.zeros((10, 10));'"
 
 [tool.cibuildwheel.macos]
-before-build = "brew install eigen fftw"
+before-all = "brew install eigen fftw"
+
+[tool.cibuildwheel.macos.environment]
+FFTW_DIR = "/opt/homebrew/opt/fftw/lib/"
+
+[tool.cibuildwheel.linux]
+before-all = "yum install -y fftw-devel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ extend-ignore = ["E501"]
 [tool.cibuildwheel]
 build = "cp311-*"  # build for CPython 3.11 Stable API
 skip = ["cp314t-*"]  # explicitly skip free-threaded builds
-test-command = "python -c 'from romanisim import ramp_fit_casertano; import galsim; galsim.fft.fft2(np.zeros((10, 10));'"
+test-command = "python -c 'import galsim; import numpy as np; from romanisim import ramp_fit_casertano; galsim.fft.fft2(np.zeros((10, 10)))'"
 
 [tool.cibuildwheel.macos]
 before-all = "brew install eigen fftw"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ extend-ignore = ["E501"]
 [tool.cibuildwheel]
 build = "cp311-*"  # build for CPython 3.11 Stable API
 skip = ["cp314t-*"]  # explicitly skip free-threaded builds
-test-command = "python -c 'from romanisim import ramp_fit_casertano'"
+test-command = "python -c 'from romanisim import ramp_fit_casertano; import galsim; galsim.fft.fft2(np.zeros((10, 10));'"
 
 [tool.cibuildwheel.macos]
 before-build = "brew install eigen fftw"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ extend-ignore = ["E501"]
 [tool.cibuildwheel]
 build = "cp311-*"  # build for CPython 3.11 Stable API
 skip = ["cp314t-*"]  # explicitly skip free-threaded builds
+test-command = "python -c 'from romanisim import ramp_fit_casertano'"
 
 [tool.cibuildwheel.macos]
 before-build = "brew install eigen fftw"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,5 +113,9 @@ exclude_lines = [
 [tool.ruff.lint]
 extend-ignore = ["E501"]
 
+[tool.cibuildwheel]
+build = "cp311-*"  # build for CPython 3.11 Stable API
+skip = ["cp314t-*"]  # explicitly skip free-threaded builds
+
 [tool.cibuildwheel.macos]
 before-build = "brew install eigen fftw"

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,22 @@ import numpy as np
 Options.docstrings = True
 Options.annotate = False
 
+define_macros = [
+    ("NUMPY", "1"),
+    ("Py_LIMITED_API", 0x030B0000),  # PY_VERSION_HEX for 3.11
+]
+
 # importing these extension modules is tested in `.github/workflows/build.yml`;
 # when adding new modules here, make sure to add them to the `test_command` entry there
-extensions = [Extension('romanisim.ramp_fit_casertano',
-                        ['romanisim/ramp_fit_casertano.pyx'],
-                        include_dirs=[np.get_include()])]
+extensions = [
+    Extension(
+        "romanisim.ramp_fit_casertano",
+        ["romanisim/ramp_fit_casertano.pyx"],
+        include_dirs=[np.get_include()],
+        define_macros=define_macros,
+        py_limited_api=True,
+    )
+]
 
 scripts = [str(s) for s in Path('scripts/').iterdir()
            if s.is_file() and s.name != '__pycache__']

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ scripts = [str(s) for s in Path('scripts/').iterdir()
 
 setup(scripts=scripts,
       ext_modules=cythonize(extensions),
+      options={'bdist_wheel': {'py_limited_api': 'cp311'}},
       )


### PR DESCRIPTION
Resolves [SCSB-237](https://jira.stsci.edu/browse/SCSB-237)

building against the Limited API means we can build just ONE wheel (in this case for Python 3.11) and it should work on all future Python versions: https://docs.python.org/3/c-api/stable.html#limited-c-api