### PR TITLE
[SCSB-271] build for free-threaded Python, disabling ABI3 build if GIL is disabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3"
+          pip-install: build
       - if: ${{ runner.os == 'Linux' }}
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
@@ -37,7 +38,6 @@ jobs:
         with:
           package-dir: ./
           output-dir: dist/
-      - run: pip install build
       - run: python -m build --sdist
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,8 +114,10 @@ exclude_lines = [
 extend-ignore = ["E501"]
 
 [tool.cibuildwheel]
-build = "cp311-*"  # build for CPython 3.11 Stable API
-skip = ["cp314t-*"]  # explicitly skip free-threaded builds
+build = [
+  "cp311-*",  # build for CPython 3.11 Stable API
+  "cp3*t-*",  # build for free-threaded Python
+]
 test-command = "python -c 'import galsim; import numpy as np; from romanisim import ramp_fit_casertano; galsim.fft.fft2(np.zeros((10, 10)))'"
 
 [tool.cibuildwheel.macos]

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,21 @@
+import sysconfig
 from pathlib import Path
 
-from setuptools import setup, Extension
+import numpy as np
 from Cython.Build import cythonize
 from Cython.Compiler import Options
-import numpy as np
+from setuptools import Extension, setup
 
 Options.docstrings = True
 Options.annotate = False
 
+FREE_THREADED_PYTHON = sysconfig.get_config_var("Py_GIL_DISABLED") == 1
+
 define_macros = [
     ("NUMPY", "1"),
-    ("Py_LIMITED_API", 0x030B0000),  # PY_VERSION_HEX for 3.11
 ]
+if not FREE_THREADED_PYTHON:
+    define_macros.append(("Py_LIMITED_API", 0x030B0000))  # PY_VERSION_HEX for 3.11
 
 # importing these extension modules is tested in `.github/workflows/build.yml`;
 # when adding new modules here, make sure to add them to the `test_command` entry there
@@ -21,14 +25,19 @@ extensions = [
         ["romanisim/ramp_fit_casertano.pyx"],
         include_dirs=[np.get_include()],
         define_macros=define_macros,
-        py_limited_api=True,
+        py_limited_api=not FREE_THREADED_PYTHON,
     )
 ]
 
 scripts = [str(s) for s in Path('scripts/').iterdir()
            if s.is_file() and s.name != '__pycache__']
 
-setup(scripts=scripts,
-      ext_modules=cythonize(extensions),
-      options={'bdist_wheel': {'py_limited_api': 'cp311'}},
-      )
+SETUPTOOLS_OPTIONS = {}
+if not FREE_THREADED_PYTHON:
+    SETUPTOOLS_OPTIONS["bdist_wheel"] = {"py_limited_api": "cp311"}
+
+setup(
+    scripts=scripts,
+    ext_modules=cythonize(extensions),
+    options=SETUPTOOLS_OPTIONS,
+)


### PR DESCRIPTION
it looks like the current blocker is a lack of free-threaded Python wheels for `photutils`