### PR TITLE
Set injected L2 source fluxes from the image's photometric calibration

### DIFF
--- a/docs/romanisim/l2.rst
+++ b/docs/romanisim/l2.rst
@@ -23,6 +23,7 @@ We support L2 source injection through :meth:`romanisim.image.inject_sources_int
 
 * The model WCS is used to generate the pixel locations for sources.
 * The number of additional electrons in each pixel is simulated.
+* The number of electrons corresponding to a source of a given flux is taken from the image's photometric calibration keywords rather than from romanisim's zero point, so that injected sources are recovered with the fluxes they were given whatever gain and zero point were used to calibrate the image.  The gain affects only the noise of the injected sources.
 * A virtual ramp is created that evenly apportions the original L2 flux along the ramp.
 * The new electrons are apportioned randomly along the ramp following a Poisson distribution in the same way as for the usual L1 simulations.
 * The new ramp is then fit using the ramp fitting code, and the new fit replaces the old fit in the L2 file.

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -1196,6 +1196,47 @@ def make_asdf(slope, slopevar_rn, slopevar_poisson, metadata=None,
     return out._instance, extras
 
 
+def abflux_from_photom_keywords(model, gain):
+    """Get the electron rate of an AB source implied by an image's
+    photometric calibration.
+
+    L2 images are in DN / s, and the conversion to MJy / sr in
+    meta.photometry.conversion_megajanskys contains a factor of the gain; see
+    romanisim.util.update_photom_keywords.  Given the gain, that conversion can
+    be inverted to get the number of electron / s that the image's calibration
+    assigns to a source of one maggie; this is needed to get Poisson noise
+    calculations correct.  We therefore use this abflux computation in L2 source
+    injection given a particular gain to get roughly the right Poisson noise
+    while preserving the total fluxes consistently.
+
+    Parameters
+    ----------
+    model : roman_datamodels.datamodels.ImageModel
+        model whose photometry keywords should be inverted
+    gain : float [electron / DN]
+        gain of the image
+
+    Returns
+    -------
+    abflux : float or None
+        electron / s corresponding to a source of one maggie, or None if the
+        image lacks photometry keywords
+    """
+    if 'photometry' not in model['meta']:
+        return None
+    photometry = model['meta']['photometry']
+    if ('conversion_megajanskys' not in photometry
+            or 'pixel_area' not in photometry):
+        return None
+    conversion = photometry['conversion_megajanskys']  # MJy/sr per DN/s
+    area = photometry['pixel_area']  # sr
+    if conversion is None or area is None:
+        return None
+    # the pixel area can be negative depending on the handedness of the WCS.
+    jyperdns = np.abs(conversion * area) * 10 ** 6  # Jy per DN/s
+    return gain * 3631 / jyperdns
+
+
 def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, seed=50,
                            rng=None, gain=None, psftype='epsf'):
     """Inject sources into an L2 image.
@@ -1206,14 +1247,14 @@ def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, seed=50,
     reasonable defaults are generated from the input model.
 
     The simulation proceeds by (optionally) using the model WCS to generate the
-    x & y locations, grabbing the gain from
-    romanisim.models.parameters.reference_data, and grabbing the read_pattern from the
-    model_metadata.  The number of additional counts in each pixel are
-    simulated.  We create a "virtual" ramp that uses the input L2 image and
-    evenly apportions the measured DN/s along the ramp using the MA table.  We
-    apportion the new counts to a new ramp, and add the new ramp to the virtual
-    ramp.  We then refit the new ramp, and replace the old fit with the new
-    fit.
+    x & y locations, inverting the model's photometric calibration to get the
+    electron rate corresponding to a source of a given flux, and grabbing the
+    read_pattern from the model_metadata.  The number of additional counts in
+    each pixel are simulated.  We create a "virtual" ramp that uses the input
+    L2 image and evenly apportions the measured DN/s along the ramp using the
+    MA table.  We apportion the new counts to a new ramp, and add the new ramp
+    to the virtual ramp.  We then refit the new ramp, and replace the old fit
+    with the new fit.
 
     This simulation is not as complete as the full L2 simulation.  We do not
     include non-linearity or saturation, for example.  Identified CR hits
@@ -1239,7 +1280,10 @@ def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, seed=50,
     rng: galsim.BaseDeviate
         galsim random number generator to use
     gain: float [electron / DN]
-        gain to use when converting simulated electrons to DN
+        gain of the image.  This sets how many electrons the injected sources
+        have and so affects their Poisson noise, but their total flux
+        is set by the image's photometric calibration.  If None,
+        romanisim.models.parameters.reference_data['gain'] is used.
     psftype : One of ['epsf', 'galsim', 'stpsf]
         How to determine the PSF.
 
@@ -1280,7 +1324,15 @@ def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, seed=50,
                                  wcs=wcs, xmin=0, ymin=0)
     galsim_filter_name = models.bandpass.roman2galsim_bandpass[filter_name]
     bandpass = models.bandpass.getBandpasses(AB_zeropoint=True)[galsim_filter_name]
-    abflux = models.bandpass.get_abflux(filter_name, sca)
+    # get the electron / s rate from the input model metadata; injected fluxes
+    # must be consistent with the image's photometric calibration.
+    abflux = abflux_from_photom_keywords(model, gain)
+    if abflux is None:
+        log.warning('Image has no photometry keywords; falling back to '
+                    "romanisim's zero point.  Injected source fluxes will be "
+                    'inconsistent with the image if it is calibrated with a '
+                    'different zero point or gain.')
+        abflux = models.bandpass.get_abflux(filter_name, sca)
     read_pattern = model.meta.exposure.read_pattern
     # Should we update read_time to model.meta.exposure.frame_time?
     exptime = parameters.read_time * read_pattern[-1][-1]
@@ -1289,6 +1341,12 @@ def inject_sources_into_l2(model, cat, x=None, y=None, psf=None, seed=50,
     flux_to_counts_factor = exptime
     if not chromatic:
         flux_to_counts_factor *= abflux
+    else:
+        # chromatic sources get their electrons by integrating their SEDs
+        # against the bandpass, effectively obtaining a factor of bandpass.get_abflux(...)
+        # if get_abflux is different from the metadata-implied abflux, we can at least
+        # adjust the overall DN level by a gray constant
+        gain *= models.bandpass.get_abflux(filter_name, sca) / abflux
 
     # compute the total number of counts we got from the source
     add_objects_to_image(

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -755,6 +755,60 @@ def test_inject_source_into_image():
         af.write_to(os.path.join(artifactdir, 'dms231.asdf'))
 
 
+def test_inject_source_with_nondefault_gain():
+    """Injected fluxes must not depend on the gain used to calibrate the image.
+
+    The image is in DN / s, so the electrons of an injected source are divided
+    by the gain; the photometric calibration of the image multiplies by the
+    gain again.  These must be the same gain, or the injected fluxes come out
+    wrong; see #378.
+    """
+    gain = 1.6  # not romanisim's default gain of 2
+    parameters.n_pix = 100
+    coord = SkyCoord(ra=270 * u.deg, dec=66 * u.deg)
+    filt = 'F158'
+    meta = util.default_image_meta(coord=coord, filter_name=filt,
+                                   detector='WFI07', ma_table=4)
+    wcs.fill_in_parameters(meta, coord)
+    rng = galsim.UniformDeviate(42)
+    cat = catalog.make_dummy_table_catalog(coord, radius=0.01,
+                                           bandpasses=[filt], nobj=10, rng=rng)
+
+    defaultgain = parameters.reference_data['gain']
+    try:
+        parameters.reference_data['gain'] = gain
+        im, _ = image.simulate(meta, cat[:0], usecrds=False, psftype='epsf',
+                               level=2, rng=rng, crparam=None)
+    finally:
+        parameters.reference_data['gain'] = defaultgain
+
+    # for the gain we simulated with, the calibration implies romanisim's
+    # zero point.
+    sca = int(im.meta.instrument.detector[-2:])
+    abflux = romanisim.models.bandpass.get_abflux(filt, sca)
+    assert np.abs(
+        image.abflux_from_photom_keywords(im, gain) / abflux - 1) < 0.01
+
+    flux = 1e-7
+    catinj = cat[:1]
+    catinj[filt] = flux
+    catinj['type'] = 'PSF'
+    xpos, ypos = 50, 50
+    conversion = np.abs(im.meta.photometry.conversion_megajanskys
+                        * im.meta.photometry.pixel_area) * 10 ** 6  # Jy per DN/s
+
+    # the fluxes must be right for any gain: the default one, the right one,
+    # and a wrong one.
+    for injgain in [None, gain, 10 * gain]:
+        iminj = image.inject_sources_into_l2(im, catinj, x=[xpos], y=[ypos],
+                                             gain=injgain)
+        # convert the added DN / s back to maggies using the image's own
+        # photometric calibration; we should get the flux we injected.
+        fluxobs = np.sum(iminj.data - im.data) * conversion / 3631
+        # 10%: some of the PSF falls off of this small image.
+        assert np.abs(fluxobs / flux - 1) < 0.1
+
+
 @pytest.mark.soctests
 def test_image_input(tmpdir):
     # make some simple example images

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -794,8 +794,10 @@ def test_inject_source_with_nondefault_gain():
     catinj[filt] = flux
     catinj['type'] = 'PSF'
     xpos, ypos = 50, 50
-    conversion = np.abs(im.meta.photometry.conversion_megajanskys
-                        * im.meta.photometry.pixel_area) * 10 ** 6  # Jy per DN/s
+    # the pixel area and the conversion to physical units are both positive
+    assert im.meta.photometry.pixel_area > 0
+    conversion = (im.meta.photometry.conversion_megajanskys
+                  * im.meta.photometry.pixel_area) * 10 ** 6  # Jy per DN/s
 
     # the fluxes must be right for any gain: the default one, the right one,
     # and a wrong one.

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -716,10 +716,25 @@ def test_inject_source_into_image():
     rng = galsim.UniformDeviate(rng_seed)
     cat = catalog.make_dummy_table_catalog(coord, radius=0.1, bandpasses=[filt],
                                            nobj=2000, rng=rng)
-    # Create starting image
-    im, simcatobj = image.simulate(
-        meta, cat, usecrds=False, psftype='epsf', level=2,
-        rng=rng, crparam=None)
+    # Create starting image.  We use a gain that is not romanisim's default so
+    # that a gain inconsistent with the image's photometric calibration cannot
+    # cancel out of the injected fluxes; see #378.
+    gain = 1.6
+    defaultgain = parameters.reference_data['gain']
+    try:
+        parameters.reference_data['gain'] = gain
+        im, simcatobj = image.simulate(
+            meta, cat, usecrds=False, psftype='epsf', level=2,
+            rng=rng, crparam=None)
+    finally:
+        parameters.reference_data['gain'] = defaultgain
+
+    # the calibration has a positive pixel area and, for the gain we simulated
+    # with, implies romanisim's zero point
+    sca = int(meta['instrument']['detector'][3:])
+    abflux = romanisim.models.bandpass.get_abflux(filt, sca)  # electron/s
+    assert im.meta.photometry.pixel_area > 0
+    assert np.abs(image.abflux_from_photom_keywords(im, gain) / abflux - 1) < 0.01
 
     # Create catalog with one source for injection
     xpos, ypos = 10, 10
@@ -727,20 +742,24 @@ def test_inject_source_into_image():
     flux = 1e-7
     catinj[filt] = flux
     catinj['type'] = 'PSF'
+    fluxeps = flux * abflux  # electron/s
 
-    iminj = image.inject_sources_into_l2(im, catinj, x=[xpos], y=[ypos])
+    # The fluxes come from the image's photometric calibration rather than from
+    # the gain, so they must be the same for the default gain, the gain the
+    # image was made with, and a badly wrong gain.
+    for injgain in [None, gain, 10 * gain]:
+        iminj = image.inject_sources_into_l2(im, catinj, x=[xpos], y=[ypos],
+                                             gain=injgain)
 
-    # Test that all pixels near the PSF are different from the original values
-    assert np.all((im.data[ypos - 1:ypos + 2, xpos - 1:xpos + 2] !=
-                   iminj.data[ypos - 1:ypos + 2, xpos - 1: xpos + 2]))
+        # Test that all pixels near the PSF are different from the original values
+        assert np.all((im.data[ypos - 1:ypos + 2, xpos - 1:xpos + 2] !=
+                       iminj.data[ypos - 1:ypos + 2, xpos - 1: xpos + 2]))
 
-    # Test that pixels far from the injected source are close to the original image
-    assert np.all(im.data[-10:, -10:] == iminj.data[-10:, -10:])
+        # Test that pixels far from the injected source are close to the original image
+        assert np.all(im.data[-10:, -10:] == iminj.data[-10:, -10:])
 
-    # Test that the amount of added flux makes sense
-    fluxeps = flux * romanisim.models.bandpass.get_abflux('F158', int(meta['instrument']['detector'][3:]))  # electron/s
-    assert np.abs(np.sum(iminj.data - im.data) * parameters.reference_data['gain'] /
-                  fluxeps - 1) < 0.1
+        # Test that the amount of added flux makes sense
+        assert np.abs(np.sum(iminj.data - im.data) * gain / fluxeps - 1) < 0.1
 
     # Create log entry and artifacts
     log.info(f'DMS231: successfully injected a source into an image at x,y = {xpos},{ypos}.')
@@ -753,62 +772,6 @@ def test_inject_source_into_image():
                    'catinj': catinj,
                    'cat': cat}
         af.write_to(os.path.join(artifactdir, 'dms231.asdf'))
-
-
-def test_inject_source_with_nondefault_gain():
-    """Injected fluxes must not depend on the gain used to calibrate the image.
-
-    The image is in DN / s, so the electrons of an injected source are divided
-    by the gain; the photometric calibration of the image multiplies by the
-    gain again.  These must be the same gain, or the injected fluxes come out
-    wrong; see #378.
-    """
-    gain = 1.6  # not romanisim's default gain of 2
-    parameters.n_pix = 100
-    coord = SkyCoord(ra=270 * u.deg, dec=66 * u.deg)
-    filt = 'F158'
-    meta = util.default_image_meta(coord=coord, filter_name=filt,
-                                   detector='WFI07', ma_table=4)
-    wcs.fill_in_parameters(meta, coord)
-    rng = galsim.UniformDeviate(42)
-    cat = catalog.make_dummy_table_catalog(coord, radius=0.01,
-                                           bandpasses=[filt], nobj=10, rng=rng)
-
-    defaultgain = parameters.reference_data['gain']
-    try:
-        parameters.reference_data['gain'] = gain
-        im, _ = image.simulate(meta, cat[:0], usecrds=False, psftype='epsf',
-                               level=2, rng=rng, crparam=None)
-    finally:
-        parameters.reference_data['gain'] = defaultgain
-
-    # for the gain we simulated with, the calibration implies romanisim's
-    # zero point.
-    sca = int(im.meta.instrument.detector[-2:])
-    abflux = romanisim.models.bandpass.get_abflux(filt, sca)
-    assert np.abs(
-        image.abflux_from_photom_keywords(im, gain) / abflux - 1) < 0.01
-
-    flux = 1e-7
-    catinj = cat[:1]
-    catinj[filt] = flux
-    catinj['type'] = 'PSF'
-    xpos, ypos = 50, 50
-    # the pixel area and the conversion to physical units are both positive
-    assert im.meta.photometry.pixel_area > 0
-    conversion = (im.meta.photometry.conversion_megajanskys
-                  * im.meta.photometry.pixel_area) * 10 ** 6  # Jy per DN/s
-
-    # the fluxes must be right for any gain: the default one, the right one,
-    # and a wrong one.
-    for injgain in [None, gain, 10 * gain]:
-        iminj = image.inject_sources_into_l2(im, catinj, x=[xpos], y=[ypos],
-                                             gain=injgain)
-        # convert the added DN / s back to maggies using the image's own
-        # photometric calibration; we should get the flux we injected.
-        fluxobs = np.sum(iminj.data - im.data) * conversion / 3631
-        # 10%: some of the PSF falls off of this small image.
-        assert np.abs(fluxobs / flux - 1) < 0.1
 
 
 @pytest.mark.soctests

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -721,13 +721,11 @@ def test_inject_source_into_image():
     # cancel out of the injected fluxes; see #378.
     gain = 1.6
     defaultgain = parameters.reference_data['gain']
-    try:
-        parameters.reference_data['gain'] = gain
-        im, simcatobj = image.simulate(
-            meta, cat, usecrds=False, psftype='epsf', level=2,
-            rng=rng, crparam=None)
-    finally:
-        parameters.reference_data['gain'] = defaultgain
+    parameters.reference_data['gain'] = gain
+    im, simcatobj = image.simulate(
+        meta, cat, usecrds=False, psftype='epsf', level=2,
+        rng=rng, crparam=None)
+    parameters.reference_data['gain'] = defaultgain
 
     # the calibration has a positive pixel area and, for the gain we simulated
     # with, implies romanisim's zero point

--- a/romanisim/tests/test_util.py
+++ b/romanisim/tests/test_util.py
@@ -98,6 +98,16 @@ def test_add_more_metadata():
     assert len(metadata['exposure']) > 2  # some metadata got added.
 
 
+def test_default_image_meta():
+    meta = util.default_image_meta()
+    assert meta['instrument']['detector'] == 'WFI01'
+    meta = util.default_image_meta(detector='WFI07', ma_table=3,
+                                   filter_name='F158')
+    assert meta['instrument']['detector'] == 'WFI07'
+    assert meta['instrument']['optical_element'] == 'F158'
+    assert meta['exposure']['ma_table_number'] == 3
+
+
 def test_king_profile():
     """Test King (1962) profile routines."""
     # king_profile, sample_king_distances, random_points_in_king

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -542,8 +542,10 @@ def update_photom_keywords(im, gain=None):
             (cenpix[1], cenpix[1] + 1, cenpix[1]))
         angle = (cc[0].position_angle(cc[1]) -
                  cc[0].position_angle(cc[2]))
-        area = (cc[0].separation(cc[1]) * cc[0].separation(cc[2])
-                * np.sin(angle.to(u.rad).value))
+        # the sin(angle) term is negative for a WCS of one handedness; the
+        # area of the pixel is positive either way.
+        area = np.abs(cc[0].separation(cc[1]) * cc[0].separation(cc[2])
+                      * np.sin(angle.to(u.rad).value))
         im['meta']['photometry']['pixel_area'] = area.to(u.sr).value
         val = (gain * (3631 / bandpass.get_abflux(
              im.meta['instrument']['optical_element'], int(im.meta['instrument']['detector'][-2:])) /

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -493,11 +493,11 @@ def default_image_meta(time=None, ma_table=4, filter_name='F087',
     meta = {
         'exposure': {
             'start_time': time,
-            'ma_table_number': 4,
+            'ma_table_number': ma_table,
         },
         'instrument': {
             'optical_element': filter_name,
-            'detector': 'WFI01'
+            'detector': detector,
         },
         'wcsinfo': {
             'ra_ref': coord.ra.to(u.deg).value,

--- a/romanisim/util.py
+++ b/romanisim/util.py
@@ -542,8 +542,6 @@ def update_photom_keywords(im, gain=None):
             (cenpix[1], cenpix[1] + 1, cenpix[1]))
         angle = (cc[0].position_angle(cc[1]) -
                  cc[0].position_angle(cc[2]))
-        # the sin(angle) term is negative for a WCS of one handedness; the
-        # area of the pixel is positive either way.
         area = np.abs(cc[0].separation(cc[1]) * cc[0].separation(cc[2])
                       * np.sin(angle.to(u.rad).value))
         im['meta']['photometry']['pixel_area'] = area.to(u.sr).value


### PR DESCRIPTION
Closes #378.

In source injection conceptually the conversion between DN/s and physical units can be gotten exactly, even when the gain is incorrect.  The gain affects the electron / s and therefore the Poisson noise, but modest errors in the Poisson noise tend to be less important than errors in the zero point (or equivalently, DN/s).  Prior to this PR, inject_sources_into_l2 wasn't respecting this correctly, leading source injection with incorrect-but-close gains to lead to incorrect overall flux levels, and not just incorrect noise levels.  Full simulations are in any case unaffected.

Following this PR the consistency with the overall photometric calibration becomes paramount and the gain is only used to get the electron / s while leaving the conversion to megajansky intact.

Tests were added to make sure this works.  

The chromatic path is more complicated because the SED integration happens on the fly.  We still adjust the gain by a gray factor if the metadata conversion to megajansky is inconsistent with romanisim expectations.

Two unrelated bugs turned up in the process and are fixed in their own commits:
* `util.default_image_meta` ignored its `detector` and `ma_table` arguments and always returned WFI01 and MA table 4.
* `util.update_photom_keywords` wrote a negative `pixel_area`, and hence a negative `conversion_megajanskys`, for a WCS of one handedness, since the area carries a `sin(angle)` term.

The existing DMS231 source injection test now makes its image with a gain of 1.6 rather than the default and injects with several gains, checking that the recovered fluxes do not depend on the gain used.