### PR TITLE
Use `psf_noipc` array from CRDS epsf reference

### DIFF
--- a/docs/romanisim/refs.rst
+++ b/docs/romanisim/refs.rst
@@ -44,6 +44,11 @@ EPSF
 The EPSF reference provides pre-determined PSF models for all detectors and nine
 different locations on each detector. For rendering at any given position, the
 PSF is interpolated between the nearest calculated PSFs from the reference file.
+The reference file stores the PSF stamps both with and without an interpixel
+capacitance (IPC) kernel applied (the ``psf`` and ``psf_noipc`` arrays).
+romanisim applies IPC to the resultants during L1 simulation (see
+:doc:`l1`), so it renders scenes with the IPC-free ``psf_noipc`` array to
+avoid applying IPC twice.
 
 Flat field
 ----------

--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -364,11 +364,16 @@ def get_gridded_psf_model(
     The input reference files have 3 focus positions and this is using
     the in-focus images. There are also three spectral types that are
     available and this code uses the M5V spectal type.
+
+    The ``psf`` array in the reference file has already been convolved with an
+    interpixel capacitance (IPC) kernel; the ``psf_noipc`` array has not.
+    romanisim applies IPC to the resultants in ``romanisim.l1.make_l1``, so we
+    use the IPC-free ``psf_noipc`` array here to avoid applying IPC twice.
     """
     # Open the reference file data model
     # select the infocus images (0) and we have a selection of spectral types
     # A0V, G2V, and M6V, pick G2V (1)
-    psf_images = psf_ref_model.psf[focus, spectral_type, :, :, :].copy()
+    psf_images = psf_ref_model.psf_noipc[focus, spectral_type, :, :, :].copy()
 
     # get the central position of the cutouts in a list
     psf_positions_x = psf_ref_model.meta.pixel_x.data.data

--- a/romanisim/tests/test_psf.py
+++ b/romanisim/tests/test_psf.py
@@ -78,3 +78,21 @@ def test_get_epsf_from_crds_detector_varies_by_sca():
     model1 = psf.get_epsf_from_crds(1, filter_name)
     model2 = psf.get_epsf_from_crds(2, filter_name)
     assert model1.meta.instrument.detector != model2.meta.instrument.detector
+
+
+def test_get_gridded_psf_model_uses_noipc():
+    """The gridded PSF model must be built from the IPC-free ``psf_noipc``
+    array, not the IPC-convolved ``psf`` array.  romanisim.l1.make_l1 applies
+    IPC to the resultants, so using ``psf`` here would convolve IPC twice."""
+    focus, spectral_type = 0, 1
+    model = psf.get_epsf_from_crds(3, 'F087')
+    gridded = psf.get_gridded_psf_model(
+        model, focus=focus, spectral_type=spectral_type)
+
+    noipc = np.asarray(model.psf_noipc[focus, spectral_type])
+    withipc = np.asarray(model.psf[focus, spectral_type])
+
+    np.testing.assert_array_equal(gridded.data, noipc)
+    # guard against the reference file shipping identical arrays, which would
+    # make the check above pass vacuously
+    assert not np.array_equal(noipc, withipc)

--- a/romanisim/tests/test_psf.py
+++ b/romanisim/tests/test_psf.py
@@ -98,44 +98,39 @@ def test_get_gridded_psf_model_uses_noipc():
     assert not np.array_equal(noipc, withipc)
 
 
-def test_epsf_noipc_plus_romanisim_ipc_matches_psf():
-    """Convolving the reference ``psf_noipc`` array with romanisim's IPC kernel
-    must reproduce the reference ``psf`` array to high precision.
+@pytest.mark.xfail(strict=True, reason=(
+    'The CRDS ePSF reference is incorrect; the psf extension is built '
+    'from the noipc extension by directly convolving with the IPC '
+    'kernel rather than respecting the different sampling, and '
+    'loses 0.5% of the flux.  See #382.'))
+def test_epsf_noipc_plus_ipc_matches_psf():
+    """The reference ``psf`` array should be ``psf_noipc`` with IPC applied.
 
-    This checks that romanisim applies the IPC kernel in the same orientation
-    that was used to build the CRDS ePSF reference (i.e. no transpose or axis
-    flip between the implementations).  The correct orientation matches at
-    ~5e-8 while the most favorable wrong orientation (``fliplr`` of the kernel)
-    differs at ~1e-4.
+    IPC couples native detector pixels, so on an oversampled stamp it couples
+    pixels separated by the oversampling.  This test verifies that the
+    IPC-convolved ePSF matches this expectation.
     """
-    from romanisim import l1
+    from scipy import ndimage
     from romanisim.models.ipc import ipc_kernel
 
     focus, spectral_type, grid_index = 0, 1, 4
     model = psf.get_epsf_from_crds(3, 'F087')
+    oversample = model.meta.oversample
 
     noipc = np.asarray(model.psf_noipc[focus, spectral_type, grid_index],
                        dtype=np.float64)
     withipc = np.asarray(model.psf[focus, spectral_type, grid_index],
                          dtype=np.float64)
 
-    # No kernel argument -> uses the default romanisim.models.ipc.ipc_kernel,
-    # the same path make_l1 takes when ipc_model is None.
-    convolved = l1.add_ipc(noipc[None, :, :])[0]
+    # IPC on native pixels, expressed on the oversampled grid: the 3x3 kernel
+    # linking only subpixels oversample apart.
+    kernel = np.zeros((2 * oversample + 1, 2 * oversample + 1))
+    kernel[::oversample, ::oversample] = ipc_kernel
 
-    # psf and psf_noipc in the reference file carry a constant relative
-    # normalization (withipc.sum() / noipc.sum() =  0.994599), so
-    # compare after normalizing both to unit sum.  The metric is the largest
-    # absolute deviation as a fraction of the reference peak.
-    ref = withipc / withipc.sum()
+    convolved = ndimage.convolve(noipc, kernel, mode='constant', cval=0)
 
-    def peak_resid(arr):
-        arr = arr / arr.sum()
-        return np.max(np.abs(arr - ref)) / np.max(ref)
+    # the kernel sums to one, so IPC redistributes flux without destroying it
+    assert np.isclose(withipc.sum(), noipc.sum(), rtol=1e-5)
 
-    assert peak_resid(convolved) < 1e-6
-
-    # The kernel is asymmetric enough that a flipped application is caught:
-    # this proves the check above is actually orientation-sensitive.
-    flipped = l1.add_ipc(noipc[None, :, :], np.asarray(ipc_kernel)[:, ::-1])[0]
-    assert peak_resid(flipped) > 1e-5
+    resid = np.max(np.abs(convolved - withipc)) / np.max(withipc)
+    assert resid < 1e-6

--- a/romanisim/tests/test_psf.py
+++ b/romanisim/tests/test_psf.py
@@ -107,16 +107,6 @@ def test_epsf_noipc_plus_romanisim_ipc_matches_psf():
     flip between the implementations).  The correct orientation matches at
     ~5e-8 while the most favorable wrong orientation (``fliplr`` of the kernel)
     differs at ~1e-4.
-
-    Notes
-    -----
-    The reference ``psf`` array was produced by stpsf using a kernel that
-    matches romanisim's built-in default ``romanisim.models.ipc.ipc_kernel``
-    (both descend from the same draft WFI simulation documentation).  A change
-    to either kernel would legitimately break this test.  This exercises only
-    the ``usecrds=False`` kernel path; with ``usecrds=True`` ``make_l1`` applies
-    the CRDS ``ipc`` reference kernel instead, which differs from this one by
-    ~15-25% in the wings.
     """
     from romanisim import l1
     from romanisim.models.ipc import ipc_kernel

--- a/romanisim/tests/test_psf.py
+++ b/romanisim/tests/test_psf.py
@@ -96,3 +96,56 @@ def test_get_gridded_psf_model_uses_noipc():
     # guard against the reference file shipping identical arrays, which would
     # make the check above pass vacuously
     assert not np.array_equal(noipc, withipc)
+
+
+def test_epsf_noipc_plus_romanisim_ipc_matches_psf():
+    """Convolving the reference ``psf_noipc`` array with romanisim's IPC kernel
+    must reproduce the reference ``psf`` array to high precision.
+
+    This checks that romanisim applies the IPC kernel in the same orientation
+    that was used to build the CRDS ePSF reference (i.e. no transpose or axis
+    flip between the implementations).  The correct orientation matches at
+    ~5e-8 while the most favorable wrong orientation (``fliplr`` of the kernel)
+    differs at ~1e-4.
+
+    Notes
+    -----
+    The reference ``psf`` array was produced by stpsf using a kernel that
+    matches romanisim's built-in default ``romanisim.models.ipc.ipc_kernel``
+    (both descend from the same draft WFI simulation documentation).  A change
+    to either kernel would legitimately break this test.  This exercises only
+    the ``usecrds=False`` kernel path; with ``usecrds=True`` ``make_l1`` applies
+    the CRDS ``ipc`` reference kernel instead, which differs from this one by
+    ~15-25% in the wings.
+    """
+    from romanisim import l1
+    from romanisim.models.ipc import ipc_kernel
+
+    focus, spectral_type, grid_index = 0, 1, 4
+    model = psf.get_epsf_from_crds(3, 'F087')
+
+    noipc = np.asarray(model.psf_noipc[focus, spectral_type, grid_index],
+                       dtype=np.float64)
+    withipc = np.asarray(model.psf[focus, spectral_type, grid_index],
+                         dtype=np.float64)
+
+    # No kernel argument -> uses the default romanisim.models.ipc.ipc_kernel,
+    # the same path make_l1 takes when ipc_model is None.
+    convolved = l1.add_ipc(noipc[None, :, :])[0]
+
+    # psf and psf_noipc in the reference file carry a constant relative
+    # normalization (withipc.sum() / noipc.sum() =  0.994599), so
+    # compare after normalizing both to unit sum.  The metric is the largest
+    # absolute deviation as a fraction of the reference peak.
+    ref = withipc / withipc.sum()
+
+    def peak_resid(arr):
+        arr = arr / arr.sum()
+        return np.max(np.abs(arr - ref)) / np.max(ref)
+
+    assert peak_resid(convolved) < 1e-6
+
+    # The kernel is asymmetric enough that a flipped application is caught:
+    # this proves the check above is actually orientation-sensitive.
+    flipped = l1.add_ipc(noipc[None, :, :], np.asarray(ipc_kernel)[:, ::-1])[0]
+    assert peak_resid(flipped) > 1e-5


### PR DESCRIPTION
Fixes #381