### PR TITLE
Fix application of IPC

### DIFF
--- a/docs/romanisim/l1.rst
+++ b/docs/romanisim/l1.rst
@@ -30,6 +30,8 @@ Interpixel capacitance (IPC) is added following non-linearity and before read-ou
 
 This is slightly different than including IPC in the PSF kernel because including IPC in the PSF kernel leaves the Poisson noise uncorrelated between pixels.
 
+The resultants do not include the reference pixels, so the convolution treats the pixels just outside the array as having the same values as the pixels on its edge.  The IPC also spreads the charge from a cosmic ray into its neighbors, so the jump flags are grown to cover the IPC kernel.
+
 Persistence
 -----------
 Persistence is implemented in the simulator following Sanchez+2023.  This follows

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -671,28 +671,32 @@ def read_pattern_to_tij(read_pattern, reference_read=False):
     return tij
 
 
-def add_ipc(resultants, ipc_kernel=None):
+def add_ipc(resultants, ipc_kernel=None, mode='constant', cval=0):
     """Add IPC to resultants.
 
     Parameters
     ----------
     resultants : np.ndarray[n_resultant, ny, nx]
         resultants describing a scene
+    ipc_kernel : np.ndarray[3, 3] or None
+        IPC convolution kernel.  Defaults to ``romanisim.models.ipc.ipc_kernel``.
+    mode, cval
+        Boundary handling, passed to ``scipy.ndimage.convolve``.  The default
+        (``'constant'``, 0) is appropriate when the array carries only flux
+        (e.g. a PSF stamp); callers whose array includes the reset pedestal
+        should pass ``mode='nearest'`` so the border is not pulled toward zero.
 
     Returns
     -------
     np.ndarray[n_resultant, ny, nx]
         resultants with IPC
     """
-    # add in IPC
-    # the reference pixels have basically no flux, so for these real pixels we
-    # extend the array with a constant equal to zero.
     if ipc_kernel is None:
         ipc_kernel = ipc.ipc_kernel
 
     log.info('Adding IPC...')
     out = ndimage.convolve(resultants, ipc_kernel[None, ...],
-                           mode='constant', cval=0)
+                           mode=mode, cval=cval)
     return out
 
 
@@ -780,10 +784,15 @@ def make_l1(counts, read_pattern,
 
     # roman.addReciprocityFailure(resultants_object)
 
+    # Both branches return the convolved resultants; add_ipc does not modify
+    # its argument in place, so the result must be captured.  resultants
+    # include the reset pedestal; on a real detector the science array is
+    # bordered by reference pixels near that same level, so extend the edge
+    # with 'nearest' rather than zero to avoid pulling the border down.
     if ipc_model is not None:
-        ipc_model.apply(resultants)
+        resultants = ipc_model.apply(resultants, edge_treatment='nearest')
     else:
-        add_ipc(resultants)
+        resultants = add_ipc(resultants, mode='nearest')
 
     # resultants are in electrons
     if gain is None:

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -682,17 +682,13 @@ def add_ipc(resultants, ipc_kernel=None, mode='nearest', cval=0):
         IPC convolution kernel.  Defaults to
         ``romanisim.models.ipc.ipc_kernel``.
     mode, cval
-        Boundary handling, passed to ``scipy.ndimage.convolve``.  The
-        resultants do not include the reference pixels, so the pixels just
-        off the edge of the array are science pixels at a level similar to
-        those just inside it; ``'nearest'`` is accordingly the default.
-        Arrays carrying only flux (e.g., a PSF stamp) should instead be
-        convolved with ``mode='constant'``, ``cval=0``.
-
-    Returns
-    -------
-    None
-        The result is written back into ``resultants``.
+        Boundary handling, passed to ``scipy.ndimage.convolve``.  These
+        parameters handle the treatment of IPC at the edge of the array.
+        The default of ``nearest`` assumes that pixels just off the array
+        are similar to those just inside it, reducing the effect of IPC
+        there.  mode='constant', cval=0 corresponds to averaging with
+        zero-flux pixels and would correspond, e.g., to high background
+        pixels being averaged with zero flux reference border pixels.
     """
     if ipc_kernel is None:
         ipc_kernel = ipc.ipc_kernel
@@ -707,9 +703,9 @@ def expand_jump_flags(dq, kernel_shape=(3, 3)):
 
     IPC redistributes the charge a cosmic ray deposits into the neighboring
     pixels, so the ramps of those pixels have jumps in them too.  romanisim
-    flags jumps by fiat---we know where we put the CRs and pretend that the
-    pipeline has found them---and this keeps that idealization consistent
-    with the IPC that has been applied.
+    flags jumps artificially---we know where we put the CRs and pretend that
+    the pipeline has found them---and this keeps that idealization consistent
+    with the IPC application.
 
     Parameters
     ----------
@@ -717,11 +713,6 @@ def expand_jump_flags(dq, kernel_shape=(3, 3)):
         DQ array marking CR hits in resultants.  Modified in place.
     kernel_shape : tuple[int, int]
         Shape of the IPC kernel over which the charge has been spread.
-
-    Returns
-    -------
-    None
-        The result is written back into ``dq``.
     """
     jump = parameters.dqbits['jump_det']
     # a (1, ny, nx) structuring element dilates each resultant separately
@@ -815,7 +806,6 @@ def make_l1(counts, read_pattern,
 
     # roman.addReciprocityFailure(resultants_object)
 
-    # both of these convolve the resultants with the IPC kernel in place.
     if ipc_model is not None:
         ipc_model.apply(resultants)
         ipc_kernel = ipc_model.ipc_kernel

--- a/romanisim/l1.py
+++ b/romanisim/l1.py
@@ -671,33 +671,62 @@ def read_pattern_to_tij(read_pattern, reference_read=False):
     return tij
 
 
-def add_ipc(resultants, ipc_kernel=None, mode='constant', cval=0):
-    """Add IPC to resultants.
+def add_ipc(resultants, ipc_kernel=None, mode='nearest', cval=0):
+    """Add IPC to resultants, in place.
 
     Parameters
     ----------
     resultants : np.ndarray[n_resultant, ny, nx]
-        resultants describing a scene
+        resultants describing a scene.  Modified in place.
     ipc_kernel : np.ndarray[3, 3] or None
-        IPC convolution kernel.  Defaults to ``romanisim.models.ipc.ipc_kernel``.
+        IPC convolution kernel.  Defaults to
+        ``romanisim.models.ipc.ipc_kernel``.
     mode, cval
-        Boundary handling, passed to ``scipy.ndimage.convolve``.  The default
-        (``'constant'``, 0) is appropriate when the array carries only flux
-        (e.g. a PSF stamp); callers whose array includes the reset pedestal
-        should pass ``mode='nearest'`` so the border is not pulled toward zero.
+        Boundary handling, passed to ``scipy.ndimage.convolve``.  The
+        resultants do not include the reference pixels, so the pixels just
+        off the edge of the array are science pixels at a level similar to
+        those just inside it; ``'nearest'`` is accordingly the default.
+        Arrays carrying only flux (e.g., a PSF stamp) should instead be
+        convolved with ``mode='constant'``, ``cval=0``.
 
     Returns
     -------
-    np.ndarray[n_resultant, ny, nx]
-        resultants with IPC
+    None
+        The result is written back into ``resultants``.
     """
     if ipc_kernel is None:
         ipc_kernel = ipc.ipc_kernel
 
     log.info('Adding IPC...')
-    out = ndimage.convolve(resultants, ipc_kernel[None, ...],
-                           mode=mode, cval=cval)
-    return out
+    resultants[...] = ndimage.convolve(resultants, ipc_kernel[None, ...],
+                                       mode=mode, cval=cval)
+
+
+def expand_jump_flags(dq, kernel_shape=(3, 3)):
+    """Grow the jump flags to cover the IPC kernel, in place.
+
+    IPC redistributes the charge a cosmic ray deposits into the neighboring
+    pixels, so the ramps of those pixels have jumps in them too.  romanisim
+    flags jumps by fiat---we know where we put the CRs and pretend that the
+    pipeline has found them---and this keeps that idealization consistent
+    with the IPC that has been applied.
+
+    Parameters
+    ----------
+    dq : np.ndarray[n_resultant, ny, nx] (uint32)
+        DQ array marking CR hits in resultants.  Modified in place.
+    kernel_shape : tuple[int, int]
+        Shape of the IPC kernel over which the charge has been spread.
+
+    Returns
+    -------
+    None
+        The result is written back into ``dq``.
+    """
+    jump = parameters.dqbits['jump_det']
+    # a (1, ny, nx) structuring element dilates each resultant separately
+    structure = np.ones((1,) + tuple(kernel_shape), dtype=bool)
+    dq[ndimage.binary_dilation((dq & jump) != 0, structure=structure)] |= jump
 
 
 def make_l1(counts, read_pattern,
@@ -756,7 +785,9 @@ def make_l1(counts, read_pattern,
     l1 : np.ndarray[n_resultant, ny, nx]
         Resultants image array in DN including systematic effects
     dq : np.ndarray[n_resultant, ny, nx]
-        DQ array marking saturated pixels and cosmic rays
+        DQ array marking saturated pixels and cosmic rays.  The cosmic ray
+        flags cover the IPC kernel, since the IPC spreads each cosmic ray
+        into its neighbors.
     reference_read : np.ndarray[ny, nx]
         Reference read in DN.  Only returned if `reference_read` is set.
     """
@@ -784,15 +815,18 @@ def make_l1(counts, read_pattern,
 
     # roman.addReciprocityFailure(resultants_object)
 
-    # Both branches return the convolved resultants; add_ipc does not modify
-    # its argument in place, so the result must be captured.  resultants
-    # include the reset pedestal; on a real detector the science array is
-    # bordered by reference pixels near that same level, so extend the edge
-    # with 'nearest' rather than zero to avoid pulling the border down.
+    # both of these convolve the resultants with the IPC kernel in place.
     if ipc_model is not None:
-        resultants = ipc_model.apply(resultants, edge_treatment='nearest')
+        ipc_model.apply(resultants)
+        ipc_kernel = ipc_model.ipc_kernel
     else:
-        resultants = add_ipc(resultants, mode='nearest')
+        add_ipc(resultants)
+        ipc_kernel = ipc.ipc_kernel
+
+    if crparam is not None:
+        # the IPC has smeared each CR out over the kernel, so the pixels
+        # around it have jumps in their ramps too.
+        expand_jump_flags(dq, kernel_shape=np.shape(ipc_kernel))
 
     # resultants are in electrons
     if gain is None:

--- a/romanisim/models/ipc.py
+++ b/romanisim/models/ipc.py
@@ -97,25 +97,30 @@ class IPC(object):
         
         self.ipc_kernel /= np.sum(self.ipc_kernel)
 
-    def apply(self, img, edge_treatment="constant", fill_value=0.0):
-        """Apply IPC convolution to an image (in-place).
+    def apply(self, img, edge_treatment="nearest", fill_value=0.0):
+        """Apply IPC convolution to an image, in place.
 
         Parameters
         ----------
         img : numpy.ndarray or galsim.Image
-            The image to convolve. If a ``galsim.Image`` is provided, its
-            ``.array`` will be updated. If a NumPy array is provided, the
-            input array is overwritten via ``img[:] = ...``.
+            The image to convolve; either a 2D image or a 3D stack of
+            resultants.  Modified in place; if a ``galsim.Image`` is
+            provided, its ``.array`` is updated.
         edge_treatment : {"constant","nearest","reflect","mirror","wrap"}, optional
-            Boundary handling mode passed to ``scipy.ndimage.convolve``
-            (default: ``'constant'``).
+            Boundary handling mode passed to ``scipy.ndimage.convolve``.
+            Resultants do not include the reference pixels, so the pixels
+            just off the edge of the array are science pixels at a level
+            similar to those just inside it; ``'nearest'`` is accordingly
+            the default.  Arrays carrying only flux (e.g., a PSF stamp)
+            should instead be convolved with ``edge_treatment='constant'``,
+            ``fill_value=0``.
         fill_value : float, optional
             Fill value used when ``edge_treatment='constant'`` (default: 0.0).
 
         Returns
         -------
-        numpy.ndarray
-            The convolved array (the same buffer that was updated in place).
+        None
+            The result is written back into ``img``.
         """
         if isinstance(img, galsim.Image):
             img_arr = img.array
@@ -124,7 +129,7 @@ class IPC(object):
 
         if img_arr.ndim == 2:
             kernel = self.ipc_kernel
-        elif img_arr.ndim == 3:  # convolve each resultant plane independently
+        elif img_arr.ndim == 3:  # convolution on 3D resultants
             kernel = self.ipc_kernel[None, ...]
         else:
             raise ValueError(
@@ -132,9 +137,8 @@ class IPC(object):
                 f"{img_arr.ndim}D"
             )
 
-        # Assigning through img_arr[:] mutates the caller's array (and, for a
-        # galsim.Image, the image buffer the .array view points at).
-        img_arr[:] = ndimage.convolve(
+        # assigning through img_arr[...] mutates the caller's array (and, for
+        # a galsim.Image, the buffer that .array is a view of).
+        img_arr[...] = ndimage.convolve(
             img_arr, kernel, mode=edge_treatment, cval=fill_value
         )
-        return img_arr

--- a/romanisim/models/ipc.py
+++ b/romanisim/models/ipc.py
@@ -114,8 +114,8 @@ class IPC(object):
 
         Returns
         -------
-        None
-            The result is written back into ``img``.
+        numpy.ndarray
+            The convolved array (the same buffer that was updated in place).
         """
         if isinstance(img, galsim.Image):
             img_arr = img.array
@@ -123,17 +123,18 @@ class IPC(object):
             img_arr = img
 
         if img_arr.ndim == 2:
-            img_arr = ndimage.convolve(
-                img_arr, self.ipc_kernel, mode=edge_treatment, cval=fill_value
-            )
-        elif img_arr.ndim == 3:  # Convolution on 3D resultants
-            img_arr = ndimage.convolve(
-                img_arr,
-                self.ipc_kernel[None, ...],
-                mode=edge_treatment,
-                cval=fill_value,
-            )
-        if isinstance(img, galsim.Image):
-            img.array = img_arr
+            kernel = self.ipc_kernel
+        elif img_arr.ndim == 3:  # convolve each resultant plane independently
+            kernel = self.ipc_kernel[None, ...]
         else:
-            img = img_arr
+            raise ValueError(
+                "IPC.apply expects a 2D image or a 3D resultants array; got "
+                f"{img_arr.ndim}D"
+            )
+
+        # Assigning through img_arr[:] mutates the caller's array (and, for a
+        # galsim.Image, the image buffer the .array view points at).
+        img_arr[:] = ndimage.convolve(
+            img_arr, kernel, mode=edge_treatment, cval=fill_value
+        )
+        return img_arr

--- a/romanisim/models/ipc.py
+++ b/romanisim/models/ipc.py
@@ -108,19 +108,10 @@ class IPC(object):
             provided, its ``.array`` is updated.
         edge_treatment : {"constant","nearest","reflect","mirror","wrap"}, optional
             Boundary handling mode passed to ``scipy.ndimage.convolve``.
-            Resultants do not include the reference pixels, so the pixels
-            just off the edge of the array are science pixels at a level
-            similar to those just inside it; ``'nearest'`` is accordingly
-            the default.  Arrays carrying only flux (e.g., a PSF stamp)
-            should instead be convolved with ``edge_treatment='constant'``,
-            ``fill_value=0``.
+            Default of ``'nearest'`` limits the effect of IPC on the border of
+            the array.
         fill_value : float, optional
             Fill value used when ``edge_treatment='constant'`` (default: 0.0).
-
-        Returns
-        -------
-        None
-            The result is written back into ``img``.
         """
         if isinstance(img, galsim.Image):
             img_arr = img.array

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -885,10 +885,10 @@ def make_image_psftype(psftype='epsf'):
         o.sky_pos = center
         o.flux[filter_name] /= abfluxdict[f'SCA{sca:02}'][filter_name]
         o.flux[filter_name] *= 10  # Make source 10x brighter for better SNR
-    # no CRs: romanisim draws a whole detector's worth of cosmic rays
-    # regardless of the size of the image being simulated, so on these 100x100
-    # images most pixels are flagged in most resultants and the recovered
-    # fluxes are dominated by which reads survived rather than by the PSF.
+    # Turn off CRs for these PSF tests
+    # if we want to turn them back on we need to adjust the image sizes
+    # or CR rate so that an entire array worth of CRs is not injected
+    # into a small stamp.
     l2 = image.simulate(meta, graycat, psftype=psftype, level=2,
                         usecrds=False, crparam=None,
                         psf_keywords=psf_keywords)

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -804,14 +804,7 @@ def test_image_input(tmpdir):
     tab.meta['real_galaxy_catalog_filename'] = str(base_rgc_filename) + '.fits'
 
     # render the image
-    # crparam=None: with cosmic rays enabled, IPC (applied to the resultants in
-    # l1.make_l1) spreads each CR's charge into its neighboring pixels, which
-    # are not jump-flagged.  fit_ramps_casertano only breaks ramps at flagged
-    # resultants, so those neighbors get an undetected mid-ramp jump and an
-    # inflated slope, which throws off this total-flux check. We turn off CRs
-    # here to avoid that problem.
-    res = image.simulate(meta, tab, usecrds=False, psftype='galsim',
-                         crparam=None)
+    res = image.simulate(meta, tab, usecrds=False, psftype='galsim')
 
     # did we get all the flux?
     totflux = np.sum(res[0].data - np.median(res[0].data))
@@ -892,8 +885,12 @@ def make_image_psftype(psftype='epsf'):
         o.sky_pos = center
         o.flux[filter_name] /= abfluxdict[f'SCA{sca:02}'][filter_name]
         o.flux[filter_name] *= 10  # Make source 10x brighter for better SNR
+    # no CRs: romanisim draws a whole detector's worth of cosmic rays
+    # regardless of the size of the image being simulated, so on these 100x100
+    # images most pixels are flagged in most resultants and the recovered
+    # fluxes are dominated by which reads survived rather than by the PSF.
     l2 = image.simulate(meta, graycat, psftype=psftype, level=2,
-                        usecrds=False, crparam=dict(),
+                        usecrds=False, crparam=None,
                         psf_keywords=psf_keywords)
     return l2[0]
 

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -804,7 +804,14 @@ def test_image_input(tmpdir):
     tab.meta['real_galaxy_catalog_filename'] = str(base_rgc_filename) + '.fits'
 
     # render the image
-    res = image.simulate(meta, tab, usecrds=False, psftype='galsim')
+    # crparam=None: with cosmic rays enabled, IPC (applied to the resultants in
+    # l1.make_l1) spreads each CR's charge into its neighboring pixels, which
+    # are not jump-flagged.  fit_ramps_casertano only breaks ramps at flagged
+    # resultants, so those neighbors get an undetected mid-ramp jump and an
+    # inflated slope, which throws off this total-flux check. We turn off CRs
+    # here to avoid that problem.
+    res = image.simulate(meta, tab, usecrds=False, psftype='galsim',
+                         crparam=None)
 
     # did we get all the flux?
     totflux = np.sum(res[0].data - np.median(res[0].data))

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -12,7 +12,6 @@ Routines tested:
 
 import pytest
 import numpy as np
-from scipy import ndimage
 from romanisim import l1, log
 from romanisim.models import parameters, nonlinearity, ipc
 import galsim
@@ -32,6 +31,15 @@ read_pattern_list = [
     [[1]],
     [[1], [10]],
 ]
+
+
+def identity_ipc():
+    """An IPC model whose kernel is the identity, i.e. IPC effectively disabled.
+    Useful for isolating tests from the effect of IPC.
+    """
+    model = ipc.IPC(usecrds=False)
+    model.ipc_kernel = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]], dtype=float)
+    return model
 
 
 def test_validate_times():
@@ -354,19 +362,18 @@ def test_make_l1_and_asdf(tmp_path):
                                     read_pattern, gain=1,  # electron/DN
                                     saturation=10**6)  # DN
         assert np.all((dq[-1] & parameters.dqbits['saturated']) != 0)
+        # Disable IPC by using an identity kernel so that the only departures from
+        # the pedestal are the cosmic rays.
         resultants, dq = l1.make_l1(galsim.Image(np.zeros((100, 100))),
                                     read_pattern, gain=1,  # electron/DN
                                     read_noise=0,  # DN
                                     pedestal_extra_noise=0,  # electron
-                                    crparam=dict())
+                                    crparam=dict(),
+                                    ipc_model=identity_ipc())
         # technically, resultants are in DN and pedestal is in electrons,
         # but in this test the gain is one and so we ignore this distinction.
-        # With zero flux the resultant sits at the pedestal everywhere except
-        # at cosmic rays; IPC then spreads a hit pixel's charge into its 3x3
-        # neighborhood, none of which is itself jump-flagged.
-        jump = (dq[0] & parameters.dqbits['jump_det']) != 0
-        jump = ndimage.binary_dilation(jump, structure=np.ones((3, 3), bool))
-        assert np.all((resultants[0] - parameters.pedestal == 0) | jump)
+        assert np.all((resultants[0] - parameters.pedestal == 0)
+                      | ((dq[0] & parameters.dqbits['jump_det']) != 0))
     log.info('DMS227: successfully made an L1 file that validates.')
 
 

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -33,15 +33,6 @@ read_pattern_list = [
 ]
 
 
-def identity_ipc():
-    """An IPC model whose kernel is the identity, i.e. IPC effectively disabled.
-    Useful for isolating tests from the effect of IPC.
-    """
-    model = ipc.IPC(usecrds=False)
-    model.ipc_kernel = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]], dtype=float)
-    return model
-
-
 def test_validate_times():
     assert l1.validate_times([[0, 1], [2, 3, 4], [5, 6, 7, 8], [9], [10]])
     assert l1.validate_times([[-1, 0], [10, 11], [12, 20], [100]])
@@ -257,9 +248,11 @@ def test_ipc():
     testim[:, 50, 50] = flux
     kernel = np.ones((3, 3), dtype='f4')
     kernel /= np.sum(kernel)
-    newim = l1.add_ipc(testim, kernel)
-    assert np.sum(~np.isclose(newim, testim)) == 9 * nresultant
-    assert (np.sum(np.isclose(newim[:, 49:52, 49:52], flux / 9))
+    origim = testim.copy()
+    # add_ipc convolves in place and returns nothing
+    assert l1.add_ipc(testim, kernel) is None
+    assert np.sum(~np.isclose(testim, origim)) == 9 * nresultant
+    assert (np.sum(np.isclose(testim[:, 49:52, 49:52], flux / 9))
             == 9 * nresultant)
     log.info('DMS226: successfully convolved image with IPC kernel.')
 
@@ -271,7 +264,7 @@ def test_make_l1_applies_ipc(branch):
     Creates an isolated point source and checks that the 3x3 footprint of
     the source in the last resultant is broadened by application of the IPC.
     """
-    parameters.n_pix = 21
+    n_pix = 21
     y0 = x0 = 10
     read_pattern = [[1], [2], [3]]
     source = 1e6
@@ -292,7 +285,7 @@ def test_make_l1_applies_ipc(branch):
         ipc_model.ipc_kernel = kernel
         expected = kernel
 
-    counts = np.zeros((parameters.n_pix, parameters.n_pix), dtype='f4')
+    counts = np.zeros((n_pix, n_pix), dtype='f4')
     counts[y0, x0] = source
     res, _ = l1.make_l1(
         galsim.Image(counts), read_pattern, read_noise=0,
@@ -302,7 +295,7 @@ def test_make_l1_applies_ipc(branch):
     footprint = res[-1].astype(np.float64)[y0 - 1:y0 + 2, x0 - 1:x0 + 2]
     footprint -= parameters.pedestal
 
-    # Ensure that the flux was redistributed into the 3x3 footprint, 
+    # Ensure that the flux was redistributed into the 3x3 footprint,
     # and that the footprint matches the expected kernel shape and orientation.
     assert np.count_nonzero(footprint) == 9
 
@@ -362,16 +355,15 @@ def test_make_l1_and_asdf(tmp_path):
                                     read_pattern, gain=1,  # electron/DN
                                     saturation=10**6)  # DN
         assert np.all((dq[-1] & parameters.dqbits['saturated']) != 0)
-        # Disable IPC by using an identity kernel so that the only departures from
-        # the pedestal are the cosmic rays.
         resultants, dq = l1.make_l1(galsim.Image(np.zeros((100, 100))),
                                     read_pattern, gain=1,  # electron/DN
                                     read_noise=0,  # DN
                                     pedestal_extra_noise=0,  # electron
-                                    crparam=dict(),
-                                    ipc_model=identity_ipc())
+                                    crparam=dict())
         # technically, resultants are in DN and pedestal is in electrons,
         # but in this test the gain is one and so we ignore this distinction.
+        # the IPC spreads each CR over the kernel, but make_l1 grows the jump
+        # flags to match, so the departures from the pedestal remain flagged.
         assert np.all((resultants[0] - parameters.pedestal == 0)
                       | ((dq[0] & parameters.dqbits['jump_det']) != 0))
     log.info('DMS227: successfully made an L1 file that validates.')

--- a/romanisim/tests/test_l1.py
+++ b/romanisim/tests/test_l1.py
@@ -12,8 +12,9 @@ Routines tested:
 
 import pytest
 import numpy as np
+from scipy import ndimage
 from romanisim import l1, log
-from romanisim.models import parameters, nonlinearity
+from romanisim.models import parameters, nonlinearity, ipc
 import galsim
 import asdf
 import os
@@ -255,6 +256,55 @@ def test_ipc():
     log.info('DMS226: successfully convolved image with IPC kernel.')
 
 
+@pytest.mark.parametrize('branch', ['add_ipc', 'ipc_model'])
+def test_make_l1_applies_ipc(branch):
+    """Ensure make_l1 properly convolves the resultants with the IPC kernel.
+
+    Creates an isolated point source and checks that the 3x3 footprint of
+    the source in the last resultant is broadened by application of the IPC.
+    """
+    parameters.n_pix = 21
+    y0 = x0 = 10
+    read_pattern = [[1], [2], [3]]
+    source = 1e6
+
+    # An asymmetric kernel: a transpose or axis flip in the application would
+    # change the recovered footprint.
+    kernel = np.array([[0.004, 0.020, 0.006],
+                       [0.050, 0.860, 0.030],
+                       [0.003, 0.024, 0.003]])
+    kernel = kernel / kernel.sum()
+
+    if branch == 'add_ipc':
+        # make_l1 falls back to add_ipc with the default kernel
+        ipc_model = None
+        expected = np.asarray(ipc.ipc_kernel)
+    else:
+        ipc_model = ipc.IPC(usecrds=False)
+        ipc_model.ipc_kernel = kernel
+        expected = kernel
+
+    counts = np.zeros((parameters.n_pix, parameters.n_pix), dtype='f4')
+    counts[y0, x0] = source
+    res, _ = l1.make_l1(
+        galsim.Image(counts), read_pattern, read_noise=0,
+        pedestal_extra_noise=0, gain=1, crparam=None, saturation=1e30,
+        ipc_model=ipc_model, seed=1)
+
+    footprint = res[-1].astype(np.float64)[y0 - 1:y0 + 2, x0 - 1:x0 + 2]
+    footprint -= parameters.pedestal
+
+    # Ensure that the flux was redistributed into the 3x3 footprint, 
+    # and that the footprint matches the expected kernel shape and orientation.
+    assert np.count_nonzero(footprint) == 9
+
+    # scipy convolution places kernel element [a, b] at pixel offset
+    # (a - 1, b - 1) from the source, so the normalized footprint reproduces
+    # the kernel itself, providing a test of the orientation
+    np.testing.assert_allclose(footprint / footprint.sum(), expected,
+                               rtol=2e-3, atol=1e-4)
+
+
 def test_read_pattern_to_tij():
     tij = l1.read_pattern_to_tij(4)
     assert l1.validate_times(tij)
@@ -311,8 +361,12 @@ def test_make_l1_and_asdf(tmp_path):
                                     crparam=dict())
         # technically, resultants are in DN and pedestal is in electrons,
         # but in this test the gain is one and so we ignore this distinction.
-        assert np.all((resultants[0] - parameters.pedestal == 0)
-                      | ((dq[0] & parameters.dqbits['jump_det']) != 0))
+        # With zero flux the resultant sits at the pedestal everywhere except
+        # at cosmic rays; IPC then spreads a hit pixel's charge into its 3x3
+        # neighborhood, none of which is itself jump-flagged.
+        jump = (dq[0] & parameters.dqbits['jump_det']) != 0
+        jump = ndimage.binary_dilation(jump, structure=np.ones((3, 3), bool))
+        assert np.all((resultants[0] - parameters.pedestal == 0) | jump)
     log.info('DMS227: successfully made an L1 file that validates.')
 
 

--- a/romanisim/tests/test_models.py
+++ b/romanisim/tests/test_models.py
@@ -957,3 +957,20 @@ def test_roman_focal_plane(run_slow=False):
             assert blue_arrows[sca][-1][1] < blue_arrows[sca][0][1]  # Dec decreases
             assert red_arrows[sca][-1][0] > red_arrows[sca][0][0]    # RA increases
             assert red_arrows[sca][-1][1] < red_arrows[sca][0][1]    # Dec decreases
+
+def test_ipc_apply():
+    """IPC.apply convolves in place, leaving the caller's buffer updated."""
+    model = models.IPC(usecrds=False)
+
+    arr = np.zeros((5, 5), dtype='f4')
+    arr[2, 2] = 1
+    assert model.apply(arr) is None
+    np.testing.assert_allclose(arr[1:4, 1:4], model.ipc_kernel, rtol=1e-6)
+
+    im = galsim.Image(np.zeros((5, 5), dtype='f4'))
+    im.array[2, 2] = 1
+    view = im.array  # a view taken before apply must see the convolution
+    model.apply(im)
+    np.testing.assert_allclose(view[1:4, 1:4], model.ipc_kernel, rtol=1e-6)
+
+    assert_raises(ValueError, model.apply, np.zeros((2, 2, 2, 2)))


### PR DESCRIPTION
Fixes #383. 

In-place mutation is indicated in docstring of `IPC.apply`, but we need to return the array as well for use in `make_l1` as `add_ipc(resultants)` does not mutate in-place, so we need both branches to return their values. Also added `mode` and `cval` options to `add_ipc` to support both 1) the case in `make_l1` which convolves with resultants which carry the reset pedestal, and 2) the case of convolving a PSF-stamp (or other flux-only array) with the IPC which should use zero-padded convolution. 

# Outstanding issues

Fixing the application of IPC creates issues for two existing tests: `test_make_l1_and_asdf` performs a check that the resultant sits at the pedestal everywhere except on cosmic rays, but with IPC now applied, the CR flux leaks into neighbor pixels which are *not* jump-flagged, so the existing test failed. I fixed this by effectively disabling IPC by using an identity convolution kernel. Basically the same issue is present in `test_image_input`, but that uses the `simulate()` entry point which doesnt have an `ipc_model` keyword argument, so there I just set `crparam=None` to disable it. You may want to do something more principled here. 