### PR TITLE
Handle pixel-convolved and pixel-unconvolved ePSFs

### DIFF
--- a/docs/romanisim/psf.rst
+++ b/docs/romanisim/psf.rst
@@ -7,5 +7,32 @@ In the current implementation, the simulator uses a linearly varying, achromatic
 
 When using the galsim PSF, galsim's "photon shooting" mode is used for efficient rendering of chromatic sources.  When using stpsf, FFTs are used to do the convolution of the intrinsic source profile with the PSF and pixel grid of the instrument.
 
+A third mechanism, ``--psftype epsf``, takes the PSF from the CRDS ``epsf``
+reference files.  Two conventions for those files are supported, and
+romanisim tells them apart by their normalization; see
+:func:`romanisim.psf.epsf_is_pixel_convolved`.
+
+Older references hold the optical PSF on an idealized grid of square 0.11 arcsecond
+pixels, normalized so that the stamp sums to the enclosed flux fraction, and
+without convolution by the pixel response function.
+romanisim renders these by convolving with the pixel grid of the instrument.
+
+Newer reference files hold more empirical PSFs: on native pixels, and convolved
+with the pixel response
+function, with IPC already applied.  These are
+normalized so that taking every ``oversample``-th sample gives exactly the
+fraction of the flux landing in real native pixels at that subpixel offset,
+which makes the whole stamp sum to about ``oversample ** 2``.  For these
+PSFs romanisim
+
+* deconvolves the IPC, so that when constructing an L1 it can be reapplied,
+  correlating Poisson noise as will be present in real images;
+* attaches the local WCS to the stamp so that the distortion is properly tracked
+* renders the PSF with GalSim's ``no_pixel`` mode, since pixel convolution has
+  already been applied.
+
+Because these empirical PSFs already include the pixel response, they are incompatible
+with photon shooting and chromatic rendering is not available for them.
+
 .. automodapi:: romanisim.psf
 

--- a/romanisim/image.py
+++ b/romanisim/image.py
@@ -301,6 +301,19 @@ def add_objects_to_image(image, objlist, xpos, ypos, psf,
                     'Disabling fastpointsources.')
         fastpointsources = False
 
+    # A pixel-convolved ePSF already includes the pixel response function of
+    # the grid it is being drawn onto, so we should not apply it a second time.
+    # Photon-shooting mode has no equivalent of no_pixel, so it is not
+    # allowed here.
+    pixel_convolved = getattr(psf, 'pixel_convolved', False)
+    render_method = 'no_pixel' if pixel_convolved else 'auto'
+    if pixel_convolved and chromatic:
+        raise ValueError(
+            'Chromatic sources are rendered by photon shooting, which '
+            'necessarily convolves with the pixel, but this PSF has already '
+            'been convolved with the pixel response function.  Use '
+            "psftype='galsim' for chromatic rendering.")
+
     outinfo = np.zeros(len(objlist), dtype=[('counts', 'f4'), ('time', 'f4')])
     pointsources = np.zeros(len(objlist), dtype=bool)
 
@@ -336,8 +349,8 @@ def add_objects_to_image(image, objlist, xpos, ypos, psf,
                 method='phot', rng=rng)
         else:
             try:
-                stamp = final.drawImage(center=image_pos,
-                                        wcs=pwcs)
+                stamp = final.drawImage(center=image_pos, wcs=pwcs,
+                                        method=render_method)
                 if add_noise:
                     stamp.addNoise(galsim.PoissonNoise(rng))
             except galsim.GalSimFFTSizeError:
@@ -1005,6 +1018,13 @@ def simulate(metadata, objlist,
     flat = refdata['flat']
     ipc_model = refdata['ipc']
     pedestal_extra_noise = parameters.pedestal_extra_noise
+
+    # A pixel-convolved epsf reference has IPC baked in; the PSF module removes it so
+    # that make_l1 can apply it exactly once.
+    psf_keywords = dict(psf_keywords)
+    psf_keywords.setdefault(
+        'ipc_kernel',
+        ipc_model.ipc_kernel if ipc_model is not None else None)
 
     if rng is None and seed is None:
         seed = 43

--- a/romanisim/l3.py
+++ b/romanisim/l3.py
@@ -252,6 +252,9 @@ def l3_psf(bandpass, scale=0, chromatic=False, **kw):
     the limit that the output pixel scale is 1, this does nothing, but
     provides undersampled output.
 
+    A pixel-convolved ePSF already includes the pixel response function
+    and can be rendered directly using GalSim's no_pixel mode.
+
     Extra arguments are passed to romanisim.psf.make_psf.
 
     Parameters
@@ -271,17 +274,32 @@ def l3_psf(bandpass, scale=0, chromatic=False, **kw):
 
     if scale < 0 or scale > 1:
         raise ValueError('scale must be between 0 and 1')
-    convscale = romanisim.models.parameters.pixel_scale * np.sqrt(
-        1 - scale**2)
-    if scale == 1:
-        extra_convolution = None
-    else:
-        extra_convolution = galsim.Pixel(
-            convscale * romanisim.models.parameters.pixel_scale)
+    if kw.get('variable', False):
+        # A VariablePSF interpolates between the PSFs at the four corners of
+        # an SCA using detector pixel positions which isn't right for a mosaic.
+        raise ValueError('l3_psf does not support variable PSFs; the mosaic '
+                         'grid is not the detector grid')
     psf = romanisim.psf.make_psf(filter_name=bandpass,
                                  sca=romanisim.models.parameters.default_sca,
-                                 extra_convolution=extra_convolution,
                                  chromatic=chromatic, **kw)
+
+    if getattr(psf, 'pixel_convolved', False):
+        # A pixel-convolved ePSF does not require an additional convolution
+        # to account for the difference between the mosaic pixel scale and the
+        # native pixel scale
+        return psf
+
+    # convscale is already an angle; galsim.Pixel wants one.  Multiplying by
+    # pixel_scale a second time here made the box 0.11 times too small, so
+    # that for scale < 1 the mosaic PSF was missing almost the whole native
+    # pixel.
+    convscale = romanisim.models.parameters.pixel_scale * np.sqrt(
+        1 - scale**2)
+    if scale != 1:
+        psf = galsim.Convolve(psf, galsim.Pixel(convscale))
+    # galsim.Convolve returns a new object, so set the flag on the result
+    # rather than relying on it being carried over.
+    psf.pixel_convolved = False
     return psf
 
 

--- a/romanisim/models/parameters.py
+++ b/romanisim/models/parameters.py
@@ -268,11 +268,6 @@ reference_data = {
     "readnoise": 5.0,  # DN
     "saturation": 55000,  # DN
     "ipc": None,
-    # Unlike the entries above, epsf is not consumed by
-    # romanisim.image.gather_reference_data; it is read directly by
-    # romanisim.psf.get_epsf_from_crds.  Set it to a path to use a reference
-    # file that is not in CRDS, which is how a new-convention reference can
-    # be exercised before CRDS serves one.
     "epsf": None,
 }
 

--- a/romanisim/models/parameters.py
+++ b/romanisim/models/parameters.py
@@ -268,6 +268,12 @@ reference_data = {
     "readnoise": 5.0,  # DN
     "saturation": 55000,  # DN
     "ipc": None,
+    # Unlike the entries above, epsf is not consumed by
+    # romanisim.image.gather_reference_data; it is read directly by
+    # romanisim.psf.get_epsf_from_crds.  Set it to a path to use a reference
+    # file that is not in CRDS, which is how a new-convention reference can
+    # be exercised before CRDS serves one.
+    "epsf": None,
 }
 
 default_parameters_dictionary = {

--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -404,9 +404,8 @@ def deconvolve_ipc(psf_images, ipc_kernel, oversample, pad=32):
 
         A(f) = sum_ij a_ij exp(-2 pi i oversample (i f_y + j f_x))
 
-    which we divide out.  We build it analytically in order to keep
-    the result independent of whether the
-    stamp has an even or an odd number of samples on a side.
+    which we divide out, being careful to leave the PSF centering
+    unaffected.
 
     romanisim deconvolves using this function and reconvolves later in
     ``romanisim.l1.make_l1`` with the same kernel.  Away from

--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -338,8 +338,7 @@ def get_epsf_from_crds(sca, filter_name, date=None):
 
     override = reference_data.get('epsf')
     if isinstance(override, str):
-        log.info('Using epsf reference %s instead of the CRDS default',
-                 override)
+        log.info('Forcing the use of ePSF reference %s.', override)
         return datamodels.open(override)
 
     if date is None:
@@ -377,6 +376,10 @@ def epsf_is_pixel_convolved(psf_ref_model, focus=0, spectral_type=1):
     older, un-convolved reference is normalized to the enclosed-flux
     fraction and sums to slightly less than one.  We cut at a sum of 1.1.
 
+    A reference file following either convention should land close to one
+    of those two values; we warn if it does not, since that suggests the
+    file follows some third convention that we are guessing about.
+
     Parameters
     ----------
     psf_ref_model : roman_datamodels.EpsfRefModel
@@ -391,7 +394,14 @@ def epsf_is_pixel_convolved(psf_ref_model, focus=0, spectral_type=1):
         response function.
     """
     total = np.sum(psf_ref_model.psf[focus, spectral_type, 0, :, :])
-    return bool(total > 1.1)  # mildly larger than 1 to provide some buffer
+    pixel_convolved = bool(total > 1.1)  # a bit more than 1, for buffer
+    expected = psf_ref_model.meta.oversample ** 2 if pixel_convolved else 1
+    if not (0.9 * expected < total < 1.05 * expected):
+        log.warning(
+            'EPSF reference sums to %f, which is not close to the expected '
+            '%d; is this reference file following a different convention?',
+            total, expected)
+    return pixel_convolved
 
 
 def deconvolve_ipc(psf_images, ipc_kernel, oversample, pad=32):

--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -15,6 +15,7 @@ from romanisim.models import ipc
 from .models.bandpass import getBandpasses, galsim2roman_bandpass, roman2galsim_bandpass
 from .models.parameters import (
     default_date,
+    reference_data,
     n_pix,
     pixel_scale,
 )
@@ -334,6 +335,12 @@ def get_epsf_from_crds(sca, filter_name, date=None):
     model : roman_datamodels.EpsfRefModel
     """
     from crds import getreferences
+
+    override = reference_data.get('epsf')
+    if isinstance(override, str):
+        log.info('Using epsf reference %s instead of the CRDS default',
+                 override)
+        return datamodels.open(override)
 
     if date is None:
         date = default_date
@@ -948,7 +955,7 @@ def psf_stamp_wcs(wcs=None, pix=None, samplescale=None, oversample=None):
     A PSF can come from one of two sources, controlled by oversample or samplescale.
 
     Give ``samplescale`` for a stamp on an idealized grid of square samples
-    of that angular size (e.g., from stpsf).  This WCS will include the 
+    of that angular size (e.g., from stpsf).  This WCS will include the
     rotation of the image relative to north and the given pixel scale.
 
     Give ``oversample`` for a stamp that samples the native detector grid.

--- a/romanisim/psf.py
+++ b/romanisim/psf.py
@@ -10,6 +10,7 @@ from roman_datamodels import datamodels
 from scipy import interpolate
 
 from romanisim import log
+from romanisim.models import ipc
 
 from .models.bandpass import getBandpasses, galsim2roman_bandpass, roman2galsim_bandpass
 from .models.parameters import (
@@ -20,6 +21,9 @@ from .models.parameters import (
 from .models.psf_utils import getPSF
 
 __all__ =  ['VariablePSF',
+            'deconvolve_ipc',
+            'psf_stamp_wcs',
+            'epsf_is_pixel_convolved',
             'get_epsf_from_crds',
             'get_gridded_psf_model',
             'make_one_psf',
@@ -42,6 +46,10 @@ class VariablePSF:
         self.corners = corners
         self.psf = psf
         self.psfinterpolators = None
+        # True if the corner profiles already include the pixel response
+        # function of the grid they will be drawn onto.
+        self.pixel_convolved = all(
+            getattr(p, "pixel_convolved", False) for p in psf.values())
 
     def at_position(self, x, y):
         """Instantiate a PSF profile at (x, y).
@@ -82,7 +90,6 @@ class VariablePSF:
         oversamp_taylor=50,
         order=1,
         max_radius=100,
-        epsf=False,
     ):
         """Build the spatial Taylor expansions for an ePSF profile.
 
@@ -113,11 +120,6 @@ class VariablePSF:
             large box will be expensive in compute time and memory for
             the Taylor expansion.
             Default 100
-        epsf : boolean
-            Has the input PSF already been convolved with the pixel response
-            function (is it an ePSF)?  If True, use no_pixel to render with
-            galsim.
-            Default False
 
         Returns
         -------
@@ -183,7 +185,7 @@ class VariablePSF:
 
         for iloc, key in enumerate(["ll", "lr", "ul", "ur"]):
             image_pos = galsim.PositionD(
-                self.corners[key][1], self.corners[key][0]
+                self.corners[key][0], self.corners[key][1]
             )
             pwcs = image.wcs.local(image_pos)
             p = galsim.Convolve(pointsource, self.psf[key])
@@ -191,7 +193,7 @@ class VariablePSF:
             # Render the PSF at subpixel positions using galsim
 
             nover = oversamp_render
-            method = "no_pixel" if epsf else "auto"
+            method = "no_pixel" if self.pixel_convolved else "auto"
             allrendered = np.zeros((dn * nover, dn * nover))
 
             for i in range(nover):
@@ -353,9 +355,101 @@ def get_epsf_from_crds(sca, filter_name, date=None):
     return model
 
 
-@cache
+def epsf_is_pixel_convolved(psf_ref_model, focus=0, spectral_type=1):
+    """Determine if an epsf reference file has been pixel-convolved.
+
+    We would like a metadata flag saying whether the PSF has been convolved
+    with the pixel response function, but the reference files do not carry
+    one, so we key off the normalization instead.  romancal makes the same
+    determination the same way.
+
+    The convention for a pixel-convolved reference is that taking every
+    ``oversample``-th sample gives exactly the fraction of the flux that
+    would land in real native pixels at that subpixel offset.  This convention
+    leads to an overall normalization of about ``oversample ** 2``.  An
+    older, un-convolved reference is normalized to the enclosed-flux
+    fraction and sums to slightly less than one.  We cut at a sum of 1.1.
+
+    Parameters
+    ----------
+    psf_ref_model : roman_datamodels.EpsfRefModel
+        The reference model to inspect.
+    focus, spectral_type : int
+        Indices of the plane to test; any plane will do.
+
+    Returns
+    -------
+    bool
+        True if the reference PSF has been convolved with the pixel
+        response function.
+    """
+    total = np.sum(psf_ref_model.psf[focus, spectral_type, 0, :, :])
+    return bool(total > 1.1)  # mildly larger than 1 to provide some buffer
+
+
+def deconvolve_ipc(psf_images, ipc_kernel, oversample, pad=32):
+    """Remove interpixel capacitance from oversampled PSF stamps.
+
+    IPC couples whole native pixels, so on a stamp oversampled by
+    ``oversample`` it acts as a convolution with a sparse kernel
+    which is non-zero only at pixels spaced
+    ``oversample`` samples apart.  That comb has transfer function
+
+        A(f) = sum_ij a_ij exp(-2 pi i oversample (i f_y + j f_x))
+
+    which we divide out.  We build it analytically in order to keep
+    the result independent of whether the
+    stamp has an even or an odd number of samples on a side.
+
+    romanisim deconvolves using this function and reconvolves later in
+    ``romanisim.l1.make_l1`` with the same kernel.  Away from
+    the stamp edges the two cancel to about 1e-16 of the PSF peak.
+
+    Parameters
+    ----------
+    psf_images : np.ndarray[n_psf, ny, nx]
+        Oversampled PSF stamps, IPC included.
+    ipc_kernel : np.ndarray[n, n]
+        The IPC kernel; n must be odd.  Normalized here if it is not
+        already.
+    oversample : int
+        Extent to which the PSF stamp was oversampled
+    pad : int
+        Zero padding added before the FFT so that flux does not wrap
+        around the edge of the stamp.
+
+    Returns
+    -------
+    np.ndarray[n_psf, ny, nx]
+        The stamps with IPC removed.
+    """
+    ipc_kernel = np.asarray(ipc_kernel, dtype=float)
+    if ipc_kernel.ndim != 2 or ipc_kernel.shape[0] != ipc_kernel.shape[1]:
+        raise ValueError('IPC kernel must be square and two dimensional')
+    if ipc_kernel.shape[0] % 2 == 0:
+        raise ValueError('IPC kernel must have a center; its size must be odd')
+    ipc_kernel = ipc_kernel / np.sum(ipc_kernel)
+    ny, nx = psf_images.shape[-2:]
+    padded = np.pad(np.asarray(psf_images, dtype=float),
+                    ((0, 0), (pad, pad), (pad, pad)))
+
+    fy = np.fft.fftfreq(padded.shape[-2])[:, None]
+    fx = np.fft.rfftfreq(padded.shape[-1])[None, :]
+    transfer = np.zeros((fy.size, fx.size), dtype=complex)
+    nkern = ipc_kernel.shape[0] // 2
+    for i, dy in enumerate(range(-nkern, nkern + 1)):
+        for j, dx in enumerate(range(-nkern, nkern + 1)):
+            transfer += ipc_kernel[i, j] * np.exp(
+                -2j * np.pi * oversample * (dy * fy + dx * fx))
+
+    out = np.fft.irfft2(np.fft.rfft2(padded) / transfer,
+                        s=padded.shape[-2:])
+    return out[:, pad:pad + ny, pad:pad + nx]
+
+
 def get_gridded_psf_model(
-    psf_ref_model, oversample=None, focus=0, spectral_type=1
+    psf_ref_model, oversample=None, focus=0, spectral_type=1,
+    ipc_kernel=None,
 ):
     """Generate the gridded PSF model from an EPSF reference model
 
@@ -365,15 +459,47 @@ def get_gridded_psf_model(
     the in-focus images. There are also three spectral types that are
     available and this code uses the M5V spectal type.
 
-    The ``psf`` array in the reference file has already been convolved with an
-    interpixel capacitance (IPC) kernel; the ``psf_noipc`` array has not.
-    romanisim applies IPC to the resultants in ``romanisim.l1.make_l1``, so we
-    use the IPC-free ``psf_noipc`` array here to avoid applying IPC twice.
+    Two conventions for the reference file are supported; see
+    `epsf_is_pixel_convolved` for how they are distinguished.
+    Older reference files store the optical PSF without convolution
+    by the pixel response function, not including distortion, and
+    containing a 'psf_noipc' extension that does not include the effect
+    of IPC.  Newer reference files include the pixel response function,
+    distortion, and IPC (i.e., are what an empirical view of the PSF
+    would look like on real data).
+
+    Parameters
+    ----------
+    ipc_kernel : np.ndarray[n, n] or None
+        The IPC kernel that ``make_l1`` will apply.  Only used for
+        pixel-convolved references.  If None,
+        ``romanisim.models.ipc.ipc_kernel`` is used, which is also what
+        ``make_l1`` falls back to.
+
+    Returns
+    -------
+    photutils.psf.GriddedPSFModel
+        The gridded model.  ``model.meta["pixel_convolved"]`` records which
+        convention the reference file followed.
     """
     # Open the reference file data model
     # select the infocus images (0) and we have a selection of spectral types
     # A0V, G2V, and M6V, pick G2V (1)
-    psf_images = psf_ref_model.psf_noipc[focus, spectral_type, :, :, :].copy()
+    oversample_ref = psf_ref_model.meta.oversample
+    pixel_convolved = epsf_is_pixel_convolved(psf_ref_model, focus=focus,
+                                              spectral_type=spectral_type)
+
+    if pixel_convolved:
+        psf_images = psf_ref_model.psf[focus, spectral_type, :, :, :].copy()
+        # Each sample is the flux that would land in a whole native pixel
+        # centered there; galsim wants the flux in one oversampled sample.
+        psf_images = psf_images / oversample_ref ** 2
+        if ipc_kernel is None:
+            ipc_kernel = ipc.ipc_kernel
+        psf_images = deconvolve_ipc(psf_images, ipc_kernel, oversample_ref)
+    else:
+        psf_images = psf_ref_model.psf_noipc[
+            focus, spectral_type, :, :, :].copy()
 
     # get the central position of the cutouts in a list
     psf_positions_x = psf_ref_model.meta.pixel_x.data.data
@@ -388,7 +514,8 @@ def get_gridded_psf_model(
     if oversample is None:
         oversample = psf_ref_model.meta.oversample
     meta["oversampling"] = oversample
-    meta["epsf_oversample"] = psf_ref_model.meta.oversample
+    meta["epsf_oversample"] = oversample_ref
+    meta["pixel_convolved"] = pixel_convolved
     nd = NDData(psf_images, meta=meta)
     model = GriddedPSFModel(nd)
 
@@ -405,6 +532,7 @@ def make_one_psf(
     oversample=4,
     extra_convolution=None,
     date=None,
+    ipc_kernel=None,
     **kw,
 ):
     """Make a PSF profile for Roman at a specific detector location.
@@ -469,6 +597,7 @@ def make_one_psf(
             chromatic=chromatic,
             extra_convolution=extra_convolution,
             date=date,
+            ipc_kernel=ipc_kernel,
             **kw,
         )
     else:  # Default is galsim
@@ -493,6 +622,7 @@ def make_one_psf_epsf(
     chromatic=False,
     extra_convolution=None,
     date=None,
+    ipc_kernel=None,
     **kw,
 ):
     """Make a PSF profile for Roman at a specific detector location using CRDS reftype epsf
@@ -515,6 +645,12 @@ def make_one_psf_epsf(
     date : astropy.time.Time or None
         Date of simulation. If None, current date is used. Needed for psftype='epsf'
         to choose the appropriate epsf reference.
+    ipc_kernel : np.ndarray[3, 3] or None
+        The IPC kernel to deconvolve from the ePSF.  It should match
+        the kernel that is later reapplied in romanisim.l1.make_l1.
+        If None,
+        romanisim.models.ipc.ipc_kernel is used, which is also what make_l1
+        falls back to.
     **kw : dict
         Additional keywords passed to galsim.roman.getPSF or stpsf.calc_psf,
         depending on whether stpsf is set.
@@ -523,7 +659,9 @@ def make_one_psf_epsf(
     -------
     profile : galsim.gsobject.GSObject
         galsim profile object for convolution with source profiles when
-        rendering scenes.
+        rendering scenes.  The ``pixel_convolved`` attribute records whether
+        the profile already includes the pixel response function; see
+        `romanisim.image.add_objects_to_image`.
     """
     log.info("Creating PSF from CRDS reference type epsf")
     if chromatic:
@@ -531,13 +669,19 @@ def make_one_psf_epsf(
             "romanisim does not yet support chromatic PSFs with stpsf or crds epsf"
         )
     epsf_ref_model = get_epsf_from_crds(sca, filter_name, date=date)
-    gridded_psf = get_gridded_psf_model(epsf_ref_model)
+    gridded_psf = get_gridded_psf_model(epsf_ref_model, ipc_kernel=ipc_kernel)
 
     psf = psf_from_grid(gridded_psf, *pix)
-    pixelscale = pixel_scale / gridded_psf.meta["epsf_oversample"]
+    pixel_convolved = gridded_psf.meta["pixel_convolved"]
+    oversample = gridded_psf.meta["epsf_oversample"]
+    if pixel_convolved:
+        stampwcs = psf_stamp_wcs(wcs=wcs, pix=pix, oversample=oversample)
+    else:
+        stampwcs = psf_stamp_wcs(wcs=wcs, pix=pix,
+                                 samplescale=pixel_scale / oversample)
     intimg = psfstamp_to_galsimimage(
-        psf, pixelscale, wcs=wcs, pix=pix, extra_convolution=extra_convolution
-    )
+        psf, stampwcs, extra_convolution=extra_convolution)
+    intimg.pixel_convolved = pixel_convolved
     return intimg
 
 
@@ -664,14 +808,12 @@ def make_one_psf_stpsf(
         wfi.options[key] = value
 
     psf = wfi.calc_psf(oversample=oversample, **args)
-    pixelscale = wfi.pixelscale / oversample
+    # stpsf does not apply distortion; calc_psf gives something aligned with
+    # the pixels, but with a constant sample scale.
+    stampwcs = psf_stamp_wcs(wcs=wcs, pix=pix,
+                             samplescale=wfi.pixelscale / oversample)
     intimg = psfstamp_to_galsimimage(
-        psf[0].data,
-        pixelscale,
-        wcs=wcs,
-        pix=pix,
-        extra_convolution=extra_convolution,
-    )
+        psf[0].data, stampwcs, extra_convolution=extra_convolution)
     return intimg
 
 
@@ -685,6 +827,7 @@ def make_psf(
     variable=False,
     extra_convolution=None,
     date=None,
+    ipc_kernel=None,
     **kw,
 ):
     """Make a PSF profile for Roman.
@@ -712,6 +855,9 @@ def make_psf(
         to choose the appropriate epsf reference.
     extra_convolution : galsim.gsobject.GSObject or None
         Additional convolution to add to PSF profiles
+    ipc_kernel : np.ndarray[3, 3] or None
+        The IPC kernel that romanisim.l1.make_l1 will apply; only used for
+        psftype='epsf'.  See make_one_psf_epsf.
     **kw : dict
         Additional keywords passed to make_one_psf
 
@@ -731,6 +877,7 @@ def make_psf(
             chromatic=chromatic,
             extra_convolution=extra_convolution,
             date=date,
+            ipc_kernel=ipc_kernel,
             **kw,
         )
     elif pix is not None:
@@ -755,6 +902,8 @@ def make_psf(
             pix=pix,
             chromatic=chromatic,
             extra_convolution=extra_convolution,
+            date=date,
+            ipc_kernel=ipc_kernel,
             **kw,
         )
     return VariablePSF(corners, psfs)
@@ -793,30 +942,75 @@ def psf_from_grid(psfgrid, x_0=None, y_0=None, size=185):
     return psf
 
 
-def psfstamp_to_galsimimage(
-    psf, pixelscale, wcs=None, pix=None, extra_convolution=None
-):
-    """Convert an STPSF/CRDS PSF profile to galsim.Image"""
+def psf_stamp_wcs(wcs=None, pix=None, samplescale=None, oversample=None):
+    """Build the WCS for an oversampled PSF stamp.
 
-    # stpsf doesn't do distortion
-    # calc_psf gives something aligned with the pixels, but with
-    # a constant pixel scale equal to wfi.pixelscale / oversample.
-    # we need to get the appropriate rotated WCS that matches this
-    if wcs is not None:
-        local_jacobian = wcs.local(image_pos=galsim.PositionD(pix)).getMatrix()
-        # angle of [du/dx, du/dy]
-        ang = np.arctan2(local_jacobian[0, 1], local_jacobian[0, 0])
-        rotmat = np.array(
-            [[np.cos(ang), np.sin(ang)], [-np.sin(ang), np.cos(ang)]]
-        )
-        newwcs = galsim.JacobianWCS(*(rotmat.ravel() * pixelscale))
-        # we are making a new, orthogonal, isotropic matrix for the PSF with the
-        # appropriate pixel scale.  This is intended to be the WCS for the PSF
-        # produced by stpsf.
-    else:
-        newwcs = galsim.JacobianWCS(*(np.array([1, 0, 0, 1]) * pixelscale))
+    A PSF can come from one of two sources, controlled by oversample or samplescale.
+
+    Give ``samplescale`` for a stamp on an idealized grid of square samples
+    of that angular size (e.g., from stpsf).  This WCS will include the 
+    rotation of the image relative to north and the given pixel scale.
+
+    Give ``oversample`` for a stamp that samples the native detector grid.
+    Its axes are the detector axes, so the local Jacobian maps them to the
+    sky directly and the PSF WCS needs the local plate scale and shear.
+
+    Parameters
+    ----------
+    wcs : callable or None
+        WCS of the image the PSF will be rendered into.  If None, a default
+        North-up WCS is used and ``samplescale`` is required.
+    pix : tuple (float, float)
+        Pixel location of the PSF on the focal plane.
+    samplescale : float or None
+        Angular size of one sample of the stamp, in arcseconds.
+    oversample : int or None
+        Samples per native pixel.
+
+    Returns
+    -------
+    galsim.JacobianWCS
+    """
+    if (samplescale is None) == (oversample is None):
+        raise ValueError('give exactly one of samplescale and oversample')
+
+    if wcs is None:
+        if oversample is not None:
+            raise ValueError('a native-pixel stamp needs a wcs to get the '
+                             'local Jacobian from')
         # just use a default North = up WCS
-    gimg = galsim.Image(psf, wcs=newwcs)
+        return galsim.JacobianWCS(*(np.array([1, 0, 0, 1]) * samplescale))
+
+    jacobian = wcs.local(image_pos=galsim.PositionD(pix)).getMatrix()
+    if oversample is not None:
+        return galsim.JacobianWCS(*(jacobian.ravel() / oversample))
+
+    # An idealized stamp needs only the orientation of the local pixels.  We make
+    # a new orthogonal, isotropic matrix for the PSF with the appropriate sample
+    # scale; the angle is that of [du/dx, du/dy].
+    ang = np.arctan2(jacobian[0, 1], jacobian[0, 0])
+    rotmat = np.array([[np.cos(ang), np.sin(ang)],
+                       [-np.sin(ang), np.cos(ang)]])
+    return galsim.JacobianWCS(*(rotmat.ravel() * samplescale))
+
+
+def psfstamp_to_galsimimage(psf, stampwcs, extra_convolution=None):
+    """Convert an STPSF/CRDS PSF stamp to a galsim profile.
+
+    Parameters
+    ----------
+    psf : np.ndarray
+        The oversampled PSF stamp.
+    stampwcs : galsim.wcs.BaseWCS
+        WCS of the stamp; see `psf_stamp_wcs`.
+    extra_convolution : galsim.gsobject.GSObject or None
+        Additional convolution to add to the PSF.
+
+    Returns
+    -------
+    galsim.InterpolatedImage
+    """
+    gimg = galsim.Image(psf, wcs=stampwcs)
 
     # This code block could be used to fix the centroid of Stpsf calculated
     # PSFs to be zero.  This makes downstream comparisons with Stpsf

--- a/romanisim/tests/test_image.py
+++ b/romanisim/tests/test_image.py
@@ -936,3 +936,55 @@ def set_up_image_rendering_things(psftype='epsf'):
                 graycatalog=graycatalog,
                 chromcatalog=chromcatalog, filter_name=filter_name,
                 tabcatalog=tabcat)
+
+
+def test_pixel_convolved_psf_uses_no_pixel():
+    """A pixel-convolved PSF must be drawn with no_pixel.
+
+    If the PSF already carries the pixel response function, we should not
+    convolve it with the pixel a second time.
+    """
+    imwcs = galsim.JacobianWCS(0.11, 0, 0, 0.11)
+    cat = [catalog.CatalogObject(None, galsim.DeltaFunction(),
+                                 {'F158': 1.0})]
+
+    drawn = {}
+    for label, flag in [('auto', False), ('no_pixel', True)]:
+        psfprofile = galsim.Gaussian(sigma=0.2)
+        psfprofile.pixel_convolved = flag
+        im = galsim.ImageF(64, 64, wcs=imwcs, xmin=0, ymin=0)
+        image.add_objects_to_image(
+            im, cat, [32], [32], psfprofile, flux_to_counts_factor=1000.,
+            filter_name='F158', seed=1)
+        drawn[label] = im.array.copy()
+
+    def second_moment(a):
+        y, x = np.mgrid[:a.shape[0], :a.shape[1]]
+        cx = (x * a).sum() / a.sum()
+        return ((x - cx) ** 2 * a).sum() / a.sum()
+
+    # skipping the pixel convolution must make the rendered source narrower,
+    # by about the variance of a one-pixel top hat
+    assert second_moment(drawn['auto']) > second_moment(drawn['no_pixel'])
+    np.testing.assert_allclose(
+        second_moment(drawn['auto']) - second_moment(drawn['no_pixel']),
+        1 / 12, rtol=0.05)
+
+
+def test_pixel_convolved_psf_refuses_photon_shooting():
+    """Verify that PSFs that are already pixel-convolved cannot use
+    photon shooting.
+    """
+    imwcs = galsim.JacobianWCS(0.11, 0, 0, 0.11)
+    bandpass = romanisim.models.bandpass.getBandpasses(
+        AB_zeropoint=True)['H158']
+    sed = galsim.SED('vega.txt', 'nm', 'flambda').withFlux(1, bandpass)
+    cat = [catalog.CatalogObject(None, galsim.DeltaFunction() * sed, None)]
+
+    psfprofile = galsim.Gaussian(sigma=0.2)
+    psfprofile.pixel_convolved = True
+    im = galsim.ImageF(64, 64, wcs=imwcs, xmin=0, ymin=0)
+    with pytest.raises(ValueError, match='photon shooting'):
+        image.add_objects_to_image(
+            im, cat, [32], [32], psfprofile, flux_to_counts_factor=1000.,
+            bandpass=bandpass, seed=1)

--- a/romanisim/tests/test_l3.py
+++ b/romanisim/tests/test_l3.py
@@ -621,3 +621,30 @@ def test_scaling():
     # the 2x finer sampling effectively means that you need to take the
     # four exposures and interleave them, each using 1/4 of the exposure
     # time
+
+
+@pytest.mark.parametrize('scale', [0.25, 0.5, 0.75])
+def test_l3_psf_box_size(scale):
+    """l3_psf's box must be sqrt(1 - scale**2) native pixels wide.
+
+    Together with the mosaic pixel that galsim applies when the source is
+    drawn, this keeps the mosaic PSF one native pixel wide whatever the
+    output scale.
+    """
+    bare = psf.make_psf(filter_name='F158',
+                        sca=parameters.default_sca, psftype='galsim')
+    widened = l3.l3_psf('F158', scale=scale, psftype='galsim')
+
+    added = (widened.calculateMomentRadius() ** 2
+             - bare.calculateMomentRadius() ** 2)
+    # calculateMomentRadius is the geometric mean of the second moments, so
+    # the added variance per axis is that of a box of the given width
+    expected = (parameters.pixel_scale ** 2 * (1 - scale ** 2)) / 12
+    np.testing.assert_allclose(added, expected, rtol=0.05)
+
+
+def test_l3_psf_rejects_variable():
+    """The per-detector PSF variation is not meaningful on a mosaic grid.
+    """
+    with pytest.raises(ValueError, match='does not support variable'):
+        l3.l3_psf('F158', scale=0.5, psftype='galsim', variable=True)

--- a/romanisim/tests/test_psf.py
+++ b/romanisim/tests/test_psf.py
@@ -4,7 +4,9 @@ Unit tests for PSF functions.
 import pytest
 
 import numpy as np
-from romanisim import psf
+from scipy import signal
+from romanisim import l1, psf
+from romanisim.models import ipc, parameters
 from romanisim.models.bandpass import galsim2roman_bandpass
 import galsim
 import galsim.roman
@@ -80,12 +82,22 @@ def test_get_epsf_from_crds_detector_varies_by_sca():
     assert model1.meta.instrument.detector != model2.meta.instrument.detector
 
 
+def requires_unconvolved_reference(model):
+    """Skip a test when CRDS is serving a pixel-convolved reference;
+    some current tests depend on old versions without pixel convolution.
+    """
+    if psf.epsf_is_pixel_convolved(model):
+        pytest.skip('CRDS is serving a pixel-convolved epsf reference; '
+                    'this test is about the older convention')
+
+
 def test_get_gridded_psf_model_uses_noipc():
     """The gridded PSF model must be built from the IPC-free ``psf_noipc``
     array, not the IPC-convolved ``psf`` array.  romanisim.l1.make_l1 applies
     IPC to the resultants, so using ``psf`` here would convolve IPC twice."""
     focus, spectral_type = 0, 1
     model = psf.get_epsf_from_crds(3, 'F087')
+    requires_unconvolved_reference(model)
     gridded = psf.get_gridded_psf_model(
         model, focus=focus, spectral_type=spectral_type)
 
@@ -115,6 +127,7 @@ def test_epsf_noipc_plus_ipc_matches_psf():
 
     focus, spectral_type, grid_index = 0, 1, 4
     model = psf.get_epsf_from_crds(3, 'F087')
+    requires_unconvolved_reference(model)
     oversample = model.meta.oversample
 
     noipc = np.asarray(model.psf_noipc[focus, spectral_type, grid_index],
@@ -134,3 +147,246 @@ def test_epsf_noipc_plus_ipc_matches_psf():
 
     resid = np.max(np.abs(convolved - withipc)) / np.max(withipc)
     assert resid < 1e-6
+
+
+# The oversampled stamp is 4 * 46 + 1 samples on a side, so its center sample
+# is index 92 and 92 % OVERSAMPLE == 0.  The samples that fall on native pixel
+# centers are then exactly OVERSAMPLE_STRIDE[::OVERSAMPLE], which is what
+# test_render_matches_strided_reference compares against.
+OVERSAMPLE = 4
+STAMP_SIZE = 4 * 46 + 1
+GRID_XY = [[0, 0], [0, 4092], [4092, 0], [4092, 4092]]
+
+
+# EFS: I think we can get rid of this now that some of the other hashing changed?
+class Bag:
+    """An attribute bag that hashes by identity.
+
+    types.SimpleNamespace would do, except that it defines __eq__ and so is
+    unhashable, and romanisim.psf.get_gridded_psf_model is cached.
+    """
+
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+ENCLOSED_FLUX = 0.98  # a real stamp loses a little flux off its edge
+
+
+def make_epsf_reference(pixel_convolved, size=STAMP_SIZE, sigma=1.1):
+    """Build a minimal epsf reference model, either pixel-convolved or not.
+
+    The chosen PSF is Gaussian and unrealistic; here we're just testing the
+    machinery.  Both the pixel-convolved and unconvolved references are
+    built from the same IPC-convolved array
+    and differ only by a factor of ``oversample ** 2``, which is what
+    `romanisim.psf.epsf_is_pixel_convolved` keys off.
+    The pixel-unconvolved reference additionally carries the
+    IPC-free ``psf_noipc`` array, which romanisim reads.
+
+    This function also convolves in the IPC into the appropriate arrays,
+    'psf' but not 'psf_noipc' for the pixel-unconvolved models.
+
+    Parameters
+    ----------
+    pixel_convolved : bool
+        Which convention to follow.
+    size : int
+        Samples on a side of the oversampled stamp.
+    sigma : float
+        Width of the Gaussian, in native pixels.
+
+    Returns
+    -------
+    An object paralleling roman_datamodels.EpsfRefModel closely enough for
+    romanisim.psf.get_gridded_psf_model to work.
+    """
+    coord = np.arange(size) - (size - 1) / 2
+    profile = np.exp(-(coord[:, None] ** 2 + coord[None, :] ** 2)
+                     / (2 * (sigma * OVERSAMPLE) ** 2))
+    profile *= ENCLOSED_FLUX / profile.sum()
+    # (focus, spectral_type, grid position, y, x); get_gridded_psf_model
+    # defaults to focus 0 and spectral type 1
+    stack = np.tile(profile[None, None, None], (1, 2, len(GRID_XY), 1, 1))
+
+    # IPC couples native pixels, so on the oversampled stamp its nonzero
+    # elements are OVERSAMPLE samples apart.
+    comb = np.zeros((2 * OVERSAMPLE + 1,) * 2)
+    comb[::OVERSAMPLE, ::OVERSAMPLE] = ipc.ipc_kernel
+    withipc = signal.convolve(stack, comb[None, None, None], mode='same')
+
+    meta = Bag(
+        oversample=OVERSAMPLE,
+        pixel_x=Bag(data=Bag(
+            data=np.array([xy[0] for xy in GRID_XY], dtype=float))),
+        pixel_y=Bag(data=Bag(
+            data=np.array([xy[1] for xy in GRID_XY], dtype=float))),
+    )
+
+    if pixel_convolved:
+        return Bag(psf=withipc * OVERSAMPLE ** 2, meta=meta)
+    return Bag(psf=withipc, psf_noipc=stack, meta=meta)
+
+
+def test_epsf_is_pixel_convolved():
+    """The two reference conventions are told apart by their normalization."""
+    assert not psf.epsf_is_pixel_convolved(make_epsf_reference(False))
+    assert psf.epsf_is_pixel_convolved(make_epsf_reference(True))
+
+
+def test_gridded_psf_model_normalization():
+    """get_gridded_psf_model puts both conventions in galsim's units.
+
+    galsim.InterpolatedImage takes the array sum as the profile's flux, so
+    the stamp must sum to the enclosed flux fraction either way: for a
+    pixel-convolved reference that means dividing out the oversample ** 2.
+    An older reference is already in those units, so it is only a matter of
+    reading the IPC-free array rather than the IPC-convolved one, since
+    romanisim.l1.make_l1 applies IPC later.
+    """
+    ref = make_epsf_reference(True)
+    gridded = psf.get_gridded_psf_model(ref)
+    assert gridded.meta['pixel_convolved']
+    np.testing.assert_allclose(np.sum(gridded.data[0]), ENCLOSED_FLUX,
+                               rtol=1e-6)
+
+    ref = make_epsf_reference(False)
+    gridded = psf.get_gridded_psf_model(ref)
+    assert not gridded.meta['pixel_convolved']
+    np.testing.assert_array_equal(gridded.data, ref.psf_noipc[0, 1])
+    # make sure the IPC convolution did something!
+    assert not np.array_equal(ref.psf[0, 1], ref.psf_noipc[0, 1])
+
+
+def stamp_wcs(wcs, pix, pixel_convolved):
+    """The stamp WCS make_one_psf_epsf would build for either convention."""
+    if pixel_convolved:
+        return psf.psf_stamp_wcs(wcs=wcs, pix=pix, oversample=OVERSAMPLE)
+    return psf.psf_stamp_wcs(wcs=wcs, pix=pix,
+                             samplescale=parameters.pixel_scale / OVERSAMPLE)
+
+
+def render_star(ref, wcs, pix=(2044.0, 2044.0), nout=21):
+    """Render a unit-flux star centered on a native pixel, as image.py would."""
+    gridded = psf.get_gridded_psf_model(ref)
+    pixel_convolved = gridded.meta['pixel_convolved']
+    stamp = psf.psf_from_grid(gridded, *pix, size=STAMP_SIZE)
+    profile = psf.psfstamp_to_galsimimage(stamp, stamp_wcs(wcs, pix,
+                                                           pixel_convolved))
+    method = 'no_pixel' if pixel_convolved else 'auto'
+    return galsim.Convolve(
+        galsim.DeltaFunction(flux=1.0), profile).drawImage(
+            nx=nout, ny=nout, wcs=wcs.local(), method=method).array
+
+
+@pytest.mark.parametrize('jacobian', [
+    (0.11, 0, 0, 0.11),           # isotropic
+    (0.108, 0.012, -0.009, 0.103),  # sheared, like the real distortion
+    (0.075, 0.080, -0.078, 0.072),  # rotated
+])
+def test_render_matches_strided_reference(jacobian):
+    """Rendering a star must reproduce the reference's strided samples.
+
+    The defining feature of the pixel-convolved ePSFs is that a star
+    rendered at the center of one of the tabulated subpixels is what a
+    PSF actually looks like there.  This tests that property.  It's non-trivial
+    for romanisim in that the distortion of the PSF WCS must match that of the
+    image and the IPC must be successfully deconvolved out of the stamp
+    so that it can later be applied.
+    """
+    ref = make_epsf_reference(True)
+    wcs = galsim.JacobianWCS(*jacobian)
+    nout = 21
+    rendered = render_star(ref, wcs, nout=nout)
+
+    # romanisim deconvolved the IPC out of the reference so that l1 could
+    # apply it after the Poisson noise; put it back the way l1 does.
+    rendered = signal.convolve(rendered, ipc.ipc_kernel, mode='same')
+
+    center = STAMP_SIZE // 2
+    strided = ref.psf[0, 1, 0][center % OVERSAMPLE::OVERSAMPLE,
+                               center % OVERSAMPLE::OVERSAMPLE]
+    half, mid = nout // 2, strided.shape[0] // 2
+    expected = strided[mid - half:mid + half + 1, mid - half:mid + half + 1]
+
+    np.testing.assert_allclose(rendered.sum(), expected.sum(), atol=1e-3)
+    assert np.max(np.abs(rendered - expected)) < 1e-3 * expected.max()
+
+
+def test_pixel_convolved_reference_skips_pixel_convolution():
+    """The pixel convolved PSFs look like the pixel-unconvolved PSFs,
+    modulo a pixel convolution.
+
+    The same Gaussian, presented under each convention, is rendered with
+    'auto' in the un-convolved case, so galsim applies the pixel, and with
+    'no_pixel' in the pixel-convolved case, where the reference is taken to
+    carry it already.  The rendered images should therefore differ in second
+    moment by the variance of a one-pixel top hat.  An isotropic WCS keeps
+    the two stamp frames identical so that this is the only difference.
+
+    # EFS: it's not obvious we're doing the IPC handling right here?
+    # maybe signal.convolve(rendered, ipc.ipc_kernel, ...) should be present?
+    # small effect.
+    """
+    wcs = galsim.JacobianWCS(parameters.pixel_scale, 0, 0,
+                             parameters.pixel_scale)
+    optical = render_star(make_epsf_reference(False), wcs, nout=41)
+    convolved = render_star(make_epsf_reference(True), wcs, nout=41)
+
+    def second_moment(image):
+        y, x = np.mgrid[:image.shape[0], :image.shape[1]]
+        cx = (x * image).sum() / image.sum()
+        return ((x - cx) ** 2 * image).sum() / image.sum()
+
+    assert second_moment(optical) > second_moment(convolved)
+    np.testing.assert_allclose(
+        second_moment(optical) - second_moment(convolved), 1 / 12, rtol=0.02)
+
+
+@pytest.mark.parametrize('size', [STAMP_SIZE, STAMP_SIZE - 1])
+def test_deconvolve_ipc_round_trip(size):
+    """Deconvolving IPC here and reapplying it in l1 must cancel exactly.
+
+    romanisim removes the IPC baked into a pixel-convolved reference so that
+    romanisim.l1 can reapply it later to correlate the Poisson noise.
+    This deconvolution / convolution must round-trip for even and odd sized
+    stamps.
+    """
+    ref = make_epsf_reference(True, size=size)
+    assert ref.psf.shape[-1] % 2 == size % 2
+
+    gridded = psf.get_gridded_psf_model(ref)
+    # l1 applies the kernel on the native grid; on the oversampled stamp that
+    # is the same convolution with the taps oversample samples apart.
+    reconvolved = gridded.data[:1].copy()
+    kernel = np.zeros((2 * OVERSAMPLE + 1,) * 2)
+    kernel[::OVERSAMPLE, ::OVERSAMPLE] = ipc.ipc_kernel
+    l1.add_ipc(reconvolved, ipc_kernel=kernel, mode='constant', cval=0)
+
+    expected = ref.psf[0, 1, 0] / OVERSAMPLE ** 2
+    interior = slice(2 * OVERSAMPLE, -2 * OVERSAMPLE)
+    assert np.max(np.abs(reconvolved[0] - expected)[interior, interior]) < (
+        1e-10 * expected.max())
+
+
+def test_pixel_convolved_psf_carries_distortion():
+    """A native-pixel reference is placed on the detector grid, not a square one.
+
+    The stamp axes are detector axes, so the full local Jacobian applies and
+    the PSF picks up the plate scale and shear that hold at this spot on the
+    focal plane.  An older reference is on an idealized grid of square
+    pixel_scale pixels, and keeps only the local rotation.
+    """
+    wcs = galsim.JacobianWCS(0.108, 0.012, -0.009, 0.103)
+    pix = (2044.0, 2044.0)
+
+    matrix = np.array(stamp_wcs(wcs, pix, True).getMatrix())
+    np.testing.assert_allclose(matrix, wcs.local().getMatrix() / OVERSAMPLE,
+                               rtol=1e-10)
+
+    # the older convention: an isotropic grid, so equal scales and no shear
+    scales = np.linalg.svd(
+        np.array(stamp_wcs(wcs, pix, False).getMatrix()), compute_uv=False)
+    np.testing.assert_allclose(scales[0], scales[1], rtol=1e-10)
+    np.testing.assert_allclose(scales[0],
+                               parameters.pixel_scale / OVERSAMPLE, rtol=1e-10)

--- a/romanisim/tests/test_psf.py
+++ b/romanisim/tests/test_psf.py
@@ -386,3 +386,24 @@ def test_pixel_convolved_psf_carries_distortion():
     np.testing.assert_allclose(scales[0], scales[1], rtol=1e-10)
     np.testing.assert_allclose(scales[0],
                                parameters.pixel_scale / OVERSAMPLE, rtol=1e-10)
+
+
+def test_epsf_reference_override(tmp_path, monkeypatch):
+    """reference_data['epsf'] takes precedence over the CRDS lookup.
+
+    This is how a reference file that CRDS does not serve yet --- one in the
+    new, pixel-convolved convention, say --- can be used, via romanisim's
+    --config override.
+    """
+    from roman_datamodels import datamodels
+
+    model = psf.get_epsf_from_crds(1, 'F129')
+    path = str(tmp_path / 'epsf.asdf')
+    model.save(path)
+
+    monkeypatch.setitem(parameters.reference_data, 'epsf', path)
+    psf.get_epsf_from_crds.cache_clear()
+    override = psf.get_epsf_from_crds(1, 'F129')
+    assert isinstance(override, datamodels.EpsfRefModel)
+    np.testing.assert_array_equal(override.psf, model.psf)
+    psf.get_epsf_from_crds.cache_clear()

--- a/romanisim/tests/test_psf.py
+++ b/romanisim/tests/test_psf.py
@@ -313,16 +313,6 @@ def test_pixel_convolved_reference_skips_pixel_convolution():
     carry it already.  The rendered images should therefore differ in second
     moment by the variance of a one-pixel top hat.  An isotropic WCS keeps
     the two stamp frames identical so that this is the only difference.
-
-    Neither rendering needs IPC put back, and not because the effect is
-    small.  Both conventions come out of get_gridded_psf_model IPC-free ---
-    the older one because romanisim reads psf_noipc, the pixel-convolved one
-    because romanisim deconvolves the IPC out --- so the two gridded arrays
-    are in fact identical here, to 4e-16 of the peak.  Convolving both with
-    the kernel would add the same 0.046 pix**2 to each and cancel in the
-    difference.  This is unlike test_render_matches_strided_reference, which
-    compares against the reference array itself and so does have to put the
-    IPC back.
     """
     wcs = galsim.JacobianWCS(parameters.pixel_scale, 0, 0,
                              parameters.pixel_scale)
@@ -386,24 +376,3 @@ def test_pixel_convolved_psf_carries_distortion():
     np.testing.assert_allclose(scales[0], scales[1], rtol=1e-10)
     np.testing.assert_allclose(scales[0],
                                parameters.pixel_scale / OVERSAMPLE, rtol=1e-10)
-
-
-def test_epsf_reference_override(tmp_path, monkeypatch):
-    """reference_data['epsf'] takes precedence over the CRDS lookup.
-
-    This is how a reference file that CRDS does not serve yet --- one in the
-    new, pixel-convolved convention, say --- can be used, via romanisim's
-    --config override.
-    """
-    from roman_datamodels import datamodels
-
-    model = psf.get_epsf_from_crds(1, 'F129')
-    path = str(tmp_path / 'epsf.asdf')
-    model.save(path)
-
-    monkeypatch.setitem(parameters.reference_data, 'epsf', path)
-    psf.get_epsf_from_crds.cache_clear()
-    override = psf.get_epsf_from_crds(1, 'F129')
-    assert isinstance(override, datamodels.EpsfRefModel)
-    np.testing.assert_array_equal(override.psf, model.psf)
-    psf.get_epsf_from_crds.cache_clear()

--- a/romanisim/tests/test_psf.py
+++ b/romanisim/tests/test_psf.py
@@ -3,6 +3,8 @@ Unit tests for PSF functions.
 """
 import pytest
 
+from types import SimpleNamespace
+
 import numpy as np
 from scipy import signal
 from romanisim import l1, psf
@@ -158,18 +160,6 @@ STAMP_SIZE = 4 * 46 + 1
 GRID_XY = [[0, 0], [0, 4092], [4092, 0], [4092, 4092]]
 
 
-# EFS: I think we can get rid of this now that some of the other hashing changed?
-class Bag:
-    """An attribute bag that hashes by identity.
-
-    types.SimpleNamespace would do, except that it defines __eq__ and so is
-    unhashable, and romanisim.psf.get_gridded_psf_model is cached.
-    """
-
-    def __init__(self, **kw):
-        self.__dict__.update(kw)
-
-
 ENCLOSED_FLUX = 0.98  # a real stamp loses a little flux off its edge
 
 
@@ -215,17 +205,17 @@ def make_epsf_reference(pixel_convolved, size=STAMP_SIZE, sigma=1.1):
     comb[::OVERSAMPLE, ::OVERSAMPLE] = ipc.ipc_kernel
     withipc = signal.convolve(stack, comb[None, None, None], mode='same')
 
-    meta = Bag(
+    meta = SimpleNamespace(
         oversample=OVERSAMPLE,
-        pixel_x=Bag(data=Bag(
+        pixel_x=SimpleNamespace(data=SimpleNamespace(
             data=np.array([xy[0] for xy in GRID_XY], dtype=float))),
-        pixel_y=Bag(data=Bag(
+        pixel_y=SimpleNamespace(data=SimpleNamespace(
             data=np.array([xy[1] for xy in GRID_XY], dtype=float))),
     )
 
     if pixel_convolved:
-        return Bag(psf=withipc * OVERSAMPLE ** 2, meta=meta)
-    return Bag(psf=withipc, psf_noipc=stack, meta=meta)
+        return SimpleNamespace(psf=withipc * OVERSAMPLE ** 2, meta=meta)
+    return SimpleNamespace(psf=withipc, psf_noipc=stack, meta=meta)
 
 
 def test_epsf_is_pixel_convolved():
@@ -324,9 +314,15 @@ def test_pixel_convolved_reference_skips_pixel_convolution():
     moment by the variance of a one-pixel top hat.  An isotropic WCS keeps
     the two stamp frames identical so that this is the only difference.
 
-    # EFS: it's not obvious we're doing the IPC handling right here?
-    # maybe signal.convolve(rendered, ipc.ipc_kernel, ...) should be present?
-    # small effect.
+    Neither rendering needs IPC put back, and not because the effect is
+    small.  Both conventions come out of get_gridded_psf_model IPC-free ---
+    the older one because romanisim reads psf_noipc, the pixel-convolved one
+    because romanisim deconvolves the IPC out --- so the two gridded arrays
+    are in fact identical here, to 4e-16 of the peak.  Convolving both with
+    the kernel would add the same 0.046 pix**2 to each and cancel in the
+    difference.  This is unlike test_render_matches_strided_reference, which
+    compares against the reference array itself and so does have to put the
+    IPC back.
     """
     wcs = galsim.JacobianWCS(parameters.pixel_scale, 0, 0,
                              parameters.pixel_scale)


### PR DESCRIPTION
The next set of CRDS ePSF reference files will include IPC and convolution by the native pixel, without IPC-free and pixel-free versions of the PSFs.  romanisim currently depends on the IPC and pixel-free versions.  They will also be in 'native pixel' units rather than 'idealized pixel' units that come from STPSF; that is, they will include distortion.

This PR makes changes to romanisim in order to handle these new reference files and adds associated tests and documentation.

The proof that this all works is that romanisim generated images processed through romancal using the same PSF reference file produce good agreement in centroids.  The level of agreement with this PR is shown below:
<img width="1095" height="340" alt="image" src="https://github.com/user-attachments/assets/6892f8da-95cc-4801-8f18-e8f71f8e9f31" />
Agreement is ~0.005 pix per coordinate, good but not extraordinary.  The two leading causes are some approximations in galsim (pixel phase error, reduces with lower maxk_threshold) and the fact that romanisim only linearly approximates PSF variation across the four corners, while romancal uses the full 3x3 reference file grid (spatial dependence across the detector).  But ~0.005 pix / star is pretty good so I think we can be happy with this.

The approach for handling pixel convolution is to add a new pixel_convolved attribute to the PSF object so that add_objects_to_image knows whether to render a source with 'no_pixel' mode or not.  The 'no_pixel' mode makes photon shooting impossible but we don't exercise that mode much anyway.  The mode also makes the L3 PSF simpler since it doesn't need to think about the difference between the output pixel scale (always convolved in) and the native pixel scale (only convolved in by galsim if it's the output pixel scale), which needn't be the same for L3 images.

The approach for handling IPC is to deconvolve the IPC out of the new-style reference files using the IPC kernel, so that the rest of romanisim always sees an IPC-free PSF.  IPC is then added back in during L1 creation.

The approach for handling distortion is to attach a different WCS to the PSF object depending on the type of reference file.  Old style reference files continue to include only a rotation relative to north reflecting the detector alignment and the pixel scale.  New style reference files include the local Jacobian of the WCS where the PSF was evaluated.  

We handle both new and old-style ePSF reference files by keying off the overall normalization of the CRDS reference file images; new-style reference files have normalizations roughly of oversample^2, while old-style have normalizations of roughly 1.

I developed this PR in collaboration with AI / Claude.